### PR TITLE
Travis and Appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,10 +6,10 @@ environment:
     - PROJECT: "client"
 
 install:
-  - choco install python.pypy > pypy-inst.log 2>&1 || (type pypy-inst.log & exit /b 1)
-  - set PATH=C:\tools\pypy\pypy;%PATH% # so tox can find pypy
-  - echo PyPy installed
-  - pypy --version
+#  - choco install python.pypy > pypy-inst.log 2>&1 || (type pypy-inst.log & exit /b 1)
+#  - set PATH=C:\tools\pypy\pypy;%PATH% # so tox can find pypy
+#  - echo PyPy installed
+#  - pypy --version
   - echo Installed Pythons
   - dir c:\Python*
   - C:\Python35\python -m pip install tox
@@ -18,4 +18,4 @@ build: false
 
 test_script:
   - cd "%PROJECT%"
-  - C:\Python35\python -m tox
+  - C:\Python35\python -m tox --skip-missing-interpreters

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,21 @@
+environment:
+  matrix:
+    - PROJECT: "common"
+    - PROJECT: "server"
+    - PROJECT: "web"
+    - PROJECT: "client"
+
+install:
+  - choco install python.pypy > pypy-inst.log 2>&1 || (type pypy-inst.log & exit /b 1)
+  - set PATH=C:\tools\pypy\pypy;%PATH% # so tox can find pypy
+  - echo PyPy installed
+  - pypy --version
+  - echo Installed Pythons
+  - dir c:\Python*
+  - C:\Python35\python -m pip install tox
+
+build: false
+
+test_script:
+  - cd "%PROJECT%"
+  - C:\Python35\python -m tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python
+sudo: false
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "pypy"
+env:
+  - PROJECT=client
+  - PROJECT=common
+  - PROJECT=server
+  - PROJECT=web
+install: pip install tox-travis
+script: cd $PROJECT && tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "pypy"
+#  - "pypy"
 env:
   - PROJECT=client
   - PROJECT=common

--- a/client/CHANGELOG
+++ b/client/CHANGELOG
@@ -1,4 +1,4 @@
-2.8.0 (Unreleased)
+3.0.0 (Unreleased)
 ------------------
 
 - add ``--pip-set-trusted=[yes|no|auto]`` option to ``devpi use`` to add or
@@ -9,6 +9,10 @@
 
 - add ``devpiclient_get_password`` hook which allows plugins to return a
   password based on username and server url.
+
+- drop support for Python 2.6.
+
+- drop support for devpi-server < 4.0.0.
 
 
 2.7.0 (2016-10-14)

--- a/client/devpi/__init__.py
+++ b/client/devpi/__init__.py
@@ -1,2 +1,2 @@
 
-__version__ = '2.8.0.dev0'
+__version__ = '3.0.0.dev0'

--- a/client/setup.py
+++ b/client/setup.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
     CHANGELOG = get_changelog()
 
     install_requires=["tox>=1.7.1",
-                      "devpi_common>2.0.2,<4.0",
+                      "devpi_common<4,>=3.1.0.dev0",
                       "pkginfo>=1.2b1",
                       "check-manifest>=0.28",
                       "py>=1.4.31"]

--- a/client/setup.py
+++ b/client/setup.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
       description="devpi upload/install/... workflow commands for Python "
                   "developers",
       long_description="\n\n".join([README, CHANGELOG]),
-      version='2.8.0.dev0',
+      version='3.0.0.dev0',
       packages=find_packages(),
       install_requires=install_requires,
       extras_require=extras_require,

--- a/client/testing/conftest.py
+++ b/client/testing/conftest.py
@@ -114,7 +114,11 @@ def _url_of_liveserver(clientdir):
     path = py.path.local.sysfind("devpi-server")
     assert path
     # Python 2.6 doesn't have check_output
-    run = getattr(subprocess, 'check_output', getattr(subprocess, 'check_call'))
+    if sys.platform.startswith('win'):
+        # check_output hangs on Windows
+        run = subprocess.check_call
+    else:
+        run = getattr(subprocess, 'check_output', getattr(subprocess, 'check_call'))
     try:
         args = [
             str(path), "--serverdir", str(clientdir), "--debug",

--- a/client/tox.ini
+++ b/client/tox.ini
@@ -8,7 +8,7 @@ flakes-ignore =
 
 [tox]
 minversion=1.9.2
-envlist = py26-server21,py26-version,py27,py27-lin,py34,py35,pypy
+envlist = py27-server21,py27-version,py27,py27-lin,py34,py35,pypy
 
 [testenv]
 passenv = LANG
@@ -30,11 +30,11 @@ commands = py.test --flakes --maxfail=3 {posargs}
 commands = py.test -k detox testing/test_test.py
 
 
-[testenv:py26-version]
+[testenv:py27-version]
 deps =
 commands = devpi --version
 
-[testenv:py26-server21]
+[testenv:py27-server21]
 deps = pytest
        pytest-flakes
        devpi-server>=2.1.0,<2.2.dev1

--- a/client/tox.ini
+++ b/client/tox.ini
@@ -8,11 +8,12 @@ flakes-ignore =
 
 [tox]
 minversion=1.9.2
-envlist = py26-server21,py26-version,py27,py27-lin,py34,py35,pypy,flakes
+envlist = py26-server21,py26-version,py27,py27-lin,py34,py35,pypy
 
 [testenv]
 passenv = LANG
 deps = pytest
+       pytest-flakes
        devpi-server>=3.0.0b1
        mock
        py!=1.4.32
@@ -23,19 +24,11 @@ deps = pytest
        -e
        {toxinidir}/../common
 
-commands = py.test --maxfail=3 {posargs} 
+commands = py.test --flakes --maxfail=3 {posargs}
 
 [testenv:py27-lin]
 commands = py.test -k detox testing/test_test.py
 
-
-[testenv:flakes]
-platform = linux|darwin
-deps = pytest-flakes
-       devpi-server
-       webtest
-
-commands = py.test --flakes -m flakes  devpi testing
 
 [testenv:py26-version]
 deps =
@@ -43,6 +36,7 @@ commands = devpi --version
 
 [testenv:py26-server21]
 deps = pytest
+       pytest-flakes
        devpi-server>=2.1.0,<2.2.dev1
        devpi-common==2.0.8
        py!=1.4.32

--- a/client/tox.ini
+++ b/client/tox.ini
@@ -32,6 +32,8 @@ commands = py.test -k detox testing/test_test.py
 
 [testenv:py27-version]
 deps =
+       -e
+       {toxinidir}/../common
 commands = devpi --version
 
 

--- a/client/tox.ini
+++ b/client/tox.ini
@@ -20,6 +20,8 @@ deps = pytest
        webtest
        wheel
        py27-lin: detox
+       -e
+       {toxinidir}/../common
 
 commands = py.test --maxfail=3 {posargs} 
 

--- a/client/tox.ini
+++ b/client/tox.ini
@@ -8,13 +8,13 @@ flakes-ignore =
 
 [tox]
 minversion=1.9.2
-envlist = py27-server21,py27-version,py27,py27-lin,py34,py35,pypy
+envlist = py27-server4,py27-version,py27,py27-lin,py34,py35,pypy
 
 [testenv]
 passenv = LANG
 deps = pytest
        pytest-flakes
-       devpi-server>=3.0.0b1
+       devpi-server
        mock
        py!=1.4.32
        sphinx
@@ -34,15 +34,15 @@ commands = py.test -k detox testing/test_test.py
 deps =
 commands = devpi --version
 
-[testenv:py27-server21]
+
+[testenv:py27-server4]
 deps = pytest
        pytest-flakes
-       devpi-server>=2.1.0,<2.2.dev1
-       devpi-common==2.0.8
+       devpi-server==4.0.0
        py!=1.4.32
        mock
-       pyramid==1.7.4
-       sphinx<1.5
-       waitress<1.0
-       webtest==2.0.23
+       sphinx
+       webtest
        wheel
+       -e
+       {toxinidir}/../common

--- a/common/devpi_common/request.py
+++ b/common/devpi_common/request.py
@@ -1,5 +1,5 @@
 import sys
-from requests import *  # noqa
+from requests import Session
 from requests.adapters import HTTPAdapter
 from requests.exceptions import ConnectionError, RequestException, BaseHTTPError, SSLError
 

--- a/common/devpi_common/url.py
+++ b/common/devpi_common/url.py
@@ -1,7 +1,6 @@
 
 import sys
 import posixpath
-import hashlib
 from devpi_common.types import cached_property, ensure_unicode, parse_hash_spec
 from requests.models import parse_url
 

--- a/common/testing/test_archive.py
+++ b/common/testing/test_archive.py
@@ -1,6 +1,7 @@
 from subprocess import Popen, PIPE
 import py
 import pytest
+import sys
 from devpi_common.archive import *
 datadir = py.path.local(__file__).dirpath("data")
 
@@ -23,6 +24,8 @@ def create_tarfile_fromdict(tmpdir, contentdict):
     tar = py.path.local.sysfind("tar")
     if not tar:
         pytest.skip("tar command not found")
+    if sys.platform.startswith('win'):
+        pytest.skip("tar command not working properly on Windows")
     tardir = tmpdir.join("create")
     _writedir(tardir, contentdict)
     files = [x.relto(tardir) for x in tardir.visit(lambda x: x.isfile())]

--- a/common/testing/test_url.py
+++ b/common/testing/test_url.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-
+import hashlib
 import pytest
 from devpi_common.url import *
 

--- a/common/tox.ini
+++ b/common/tox.ini
@@ -7,15 +7,11 @@ flakes-ignore =
     test_*.py ImportStarUsed ImportStarUsage
 
 [tox]
-envlist = py27,py34,py35,pypy,flakes
+envlist = py27,py34,py35,pypy
 
 
 [testenv]
-deps = pytest 
+deps = pytest
+       pytest-flakes
 
-commands = py.test {posargs}
-
-
-[testenv:flakes]
-deps = pytest-flakes
-commands = py.test --flakes -m flakes  testing
+commands = py.test --flakes {posargs}

--- a/server/tox.ini
+++ b/server/tox.ini
@@ -17,6 +17,8 @@ deps=
     pytest-catchlog
     pytest-timeout
     beautifulsoup4
+    -e
+    {toxinidir}/../common
 
 [testenv:py27-keyfs_sqlite]
 commands=
@@ -37,6 +39,8 @@ commands= py.test --flakes -m flakes test_devpi_server devpi_server
 [testenv:py27-bare]
 # we want to see if things work without dependencies
 deps=
+    -e
+    {toxinidir}/../common
 commands = devpi-server -h
 
 [testenv:upgrade]

--- a/server/tox.ini
+++ b/server/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist={py27,py34}{,-keyfs_sqlite},py35,pypy,py27-bare,flakes
+envlist={py27,py34}{,-keyfs_sqlite},py35,pypy,py27-bare
 indexserver=
     pypi = https://pypi.python.org/simple
 
@@ -9,12 +9,13 @@ setenv =
 
 changedir=test_devpi_server
 commands=
-    py.test --slow -rfsxX {posargs}
+    py.test --flakes --slow -rfsxX {posargs}
 deps=
     webtest
     py27,pypy: mock
     pytest>=3
     pytest-catchlog
+    pytest-flakes
     pytest-timeout
     beautifulsoup4
     -e
@@ -27,14 +28,6 @@ commands=
 [testenv:py34-keyfs_sqlite]
 commands=
     py.test --backend=devpi_server.keyfs_sqlite --slow -rfsxX {posargs}
-
-[testenv:flakes]
-platform=linux|darwin
-changedir=.
-deps = pytest-flakes
-       devpi-server
-       webtest
-commands= py.test --flakes -m flakes test_devpi_server devpi_server
 
 [testenv:py27-bare]
 # we want to see if things work without dependencies

--- a/web/tests/test_main.py
+++ b/web/tests/test_main.py
@@ -58,11 +58,15 @@ def test_index_projects_arg(monkeypatch, tmpdir):
 
     monkeypatch.setattr(devpi_server.main, "XOM", MyXOM)
 
-    devpi_server.main.main(
+    result = devpi_server.main.main(
+        ["devpi-server", "--serverdir", str(tmpdir), "--init"])
+    assert not result
+    result = devpi_server.main.main(
         ["devpi-server", "--serverdir", str(tmpdir), "--recreate-search-index"])
+    assert result == 0
     assert tmpdir.join('.indices').check()
-    (xom,) = xom_container
-    ix = get_indexer(xom.config)
+    (xom1, xom2) = xom_container
+    ix = get_indexer(xom2.config)
     result = ix.query_projects('foo')
     assert result['info']['found'] == 1
     assert result['items'][0]['data'] == {


### PR DESCRIPTION
Currently pypy doesn't work, because argon2 doesn't install correctly and the client tests hang with Appveyor. This is still very useful to see if basic stuff breaks in PRs etc. For releases we still need the old ways of testing.