### PR TITLE
Add option to `devpi install` to use requirements file

### DIFF
--- a/client/devpi/install.py
+++ b/client/devpi/install.py
@@ -33,9 +33,12 @@ def main(hub, args):
             del os.environ["PYTHONDONTWRITEBYTECODE"]
         except KeyError:
             pass
+        req = []
+        if args.requirement:
+            req.append('--requirement')
         hub.popen_check([pip_path, "install"] + xopt + [
             "-U", #"--force-reinstall",
-            "-i", simpleindex] + list(args.pkgspecs),
+            "-i", simpleindex] + req + list(args.pkgspecs),
             # normalize pip<1.4 and pip>=1.4 behaviour
             extraenv={"PIP_PRE": "1", "PIP_USE_WHEEL": "1"},
         )

--- a/client/devpi/main.py
+++ b/client/devpi/main.py
@@ -855,6 +855,8 @@ def install(parser):
     parser.add_argument("--venv", action="store", metavar="DIR",
         help="install into specified virtualenv (created on the fly "
              "if none exists).")
+    parser.add_argument("-r", "--requirement", action="store_true",
+        help="Install from the given requirements file.")
     parser.add_argument("pkgspecs", metavar="pkg", type=str,
         action="store", default=None, nargs="*",
         help="uri or package file for installation from current index. """

--- a/client/testing/test_install.py
+++ b/client/testing/test_install.py
@@ -32,3 +32,28 @@ def test_simple_install_venv_workflow_index_option(create_and_upload,
         "install", "--venv", venvdir, "--index", "%s/dev" % user, "-l")
     out = res.stdout.str()
     assert "example" in out and "1.2.3" in out
+
+
+def test_requirement_install_venv_workflow_index_option(create_and_upload,
+                                                   create_venv,
+                                                   devpi, out_devpi):
+    create_and_upload("example-1.2.3")
+    venvdir = create_venv()
+
+    # remember username
+    out = out_devpi("use")
+    user = re.search('\(logged in as (.+?)\)', out.stdout.str()).group(1)
+
+    # go to other index
+    devpi("use", "root/pypi")
+
+    with open("requirements_test.txt", "w") as req_file:
+        req_file.write("example==1.2.3")
+
+    res = out_devpi(
+        "install", "--venv", venvdir, "--index", "%s/dev" % user, "--requirement", req_file.name)
+    assert res.ret == 0
+    res = out_devpi(
+        "install", "--venv", venvdir, "--index", "%s/dev" % user, "-l")
+    out = res.stdout.str()
+    assert "example" in out and "1.2.3" in out


### PR DESCRIPTION
Adds -r, --requirement option to `devpi install`.
A standard requirements.txt file is then expected for the pkg argument.
These args will be passed through to pip for the install.
Includes basic unit test.