### PR TITLE
Use activated venv

### DIFF
--- a/client/devpi/install.py
+++ b/client/devpi/install.py
@@ -5,14 +5,8 @@ import py
 def main(hub, args):
     current = hub.require_valid_current_with_index()
 
-    venv = args.venv
-    if not venv:
-        venv = current.venvdir
+    venv = hub.venv
     xopt = []  # not args.verbose and ["-q"] or []
-    if venv:
-        vpath = py.path.local(venv)
-        if not vpath.check():
-            hub.popen_check(["virtualenv", "-q", venv] + xopt)
     pip_path = current.getvenvbin("pip", venvdir=venv, glob=True)
     if not pip_path:
         hub.fatal("no pip binary found")

--- a/client/devpi/install.py
+++ b/client/devpi/install.py
@@ -1,6 +1,4 @@
-
 import os
-import py
 
 def main(hub, args):
     current = hub.require_valid_current_with_index()

--- a/client/devpi/main.py
+++ b/client/devpi/main.py
@@ -533,8 +533,9 @@ def use(parser):
 
     parser.add_argument("--set-cfg", action="store_true", default=None,
         dest="setcfg",
-        help="create or modify pip/setuptools config files in home directory "
-             "so pip/easy_install will pick up the current devpi index url")
+        help="create or modify pip/setuptools config files so "
+             "pip/easy_install will pick up the current devpi index url. "
+             "If a virtualenv is activated, only its pip config will be set.")
     parser.add_argument("-t", "--pip-set-trusted", choices=["yes", "no", "auto"], default="auto",
         dest="settrusted",
         help="when used in conjunction with set-cfg, also set matching "
@@ -549,7 +550,8 @@ def use(parser):
              "config file and can be cleared with '--always-set-cfg=no'.")
     parser.add_argument("--venv", action="store", default=None,
         help="set virtual environment to use for install activities. "
-             "specify '-' to unset it.")
+             "specify '-' to unset it. "
+             "Note: an activated virtualenv will be used without needing this.")
     parser.add_argument("--urls", action="store_true",
         help="show remote endpoint urls")
     parser.add_argument("-l", action="store_true", dest="list",

--- a/client/devpi/main.py
+++ b/client/devpi/main.py
@@ -586,6 +586,7 @@ def use(parser):
     parser.add_argument("--venv", action="store", default=None,
         help="set virtual environment to use for install activities. "
              "specify '-' to unset it. "
+             "venv be created if given name doesn't already exist. "
              "Note: an activated virtualenv will be used without needing this.")
     parser.add_argument("--urls", action="store_true",
         help="show remote endpoint urls")

--- a/client/devpi/use.py
+++ b/client/devpi/use.py
@@ -343,6 +343,18 @@ def getvenv():
         return None
     return pip.dirpath().dirpath()
 
+def current_venv():
+    venv = None
+    if (hasattr(sys, 'real_prefix') or
+            (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix)):
+        venv = sys.prefix
+
+    elif "VIRTUAL_ENV" in os.environ:
+        venv = os.environ["VIRTUAL_ENV"]
+
+    return venv
+
+
 def main(hub, args=None):
     args = hub.args
     current = hub.current
@@ -366,7 +378,12 @@ def main(hub, args=None):
 
     if args.venv:
         if args.venv != "-":
-            venvname = args.venv
+            if args.venv == "yes":
+                venvname = current_venv()
+                if venvname is None:
+                    hub.fatal('Could not detect an activated virtualenv.')
+            else:
+                venvname = args.venv
             cand = hub.cwd.join(venvname, vbin, abs=True)
             if not cand.check():
                 cand = hub.path_venvbase.join(venvname, vbin)

--- a/client/devpi/use.py
+++ b/client/devpi/use.py
@@ -421,7 +421,7 @@ def main(hub, args=None):
         hub.line("no server: type 'devpi use URL' with a URL "
                  "pointing to a server or directly to an index.")
     if current.venvdir:
-        hub.info("venv for install command: %s" % current.venvdir)
+        hub.info("venv for install/set commands: %s" % current.venvdir)
     #else:
     #    hub.line("no current install venv set")
     settrusted = hub.args.settrusted == 'yes'
@@ -429,24 +429,31 @@ def main(hub, args=None):
         always_setcfg = hub.args.always_setcfg == "yes"
         hub.current.reconfigure(dict(always_setcfg=always_setcfg,
                                      settrusted=settrusted))
+    set_cfgs = []
     if hub.args.setcfg or hub.current.always_setcfg:
         if not hub.current.index:
             hub.error("no index configured: cannot set pip/easy_install index")
         else:
             indexserver = hub.current.simpleindex_auth
             searchindexserver = hub.current.searchindex_auth
-            DistutilsCfg().write_indexserver(indexserver)
-            PipCfg().write_indexserver(indexserver)
-            PipCfg().write_searchindexserver(searchindexserver)
-            BuildoutCfg().write_indexserver(indexserver)
-            if settrusted or hub.current.settrusted:
-                PipCfg().write_trustedhost(indexserver)
+            if hub.args.venv:
+                hub.line("only setting venv pip cfg, no global configuration changed")
             else:
-                PipCfg().clear_trustedhost(indexserver)
+                for cfg in DistutilsCfg(), BuildoutCfg():
+                    cfg.write_indexserver(indexserver)
+                    set_cfgs.append(cfg)
 
-    show_one_conf(hub, DistutilsCfg())
-    show_one_conf(hub, PipCfg())
-    show_one_conf(hub, BuildoutCfg())
+            pipcfg = PipCfg(venv=hub.args.venv)
+            pipcfg.write_indexserver(indexserver)
+            pipcfg.write_searchindexserver(searchindexserver)
+            if settrusted or hub.current.settrusted:
+                pipcfg.write_trustedhost(indexserver)
+            else:
+                pipcfg.clear_trustedhost(indexserver)
+
+            set_cfgs.append(pipcfg)
+    for cfg in set_cfgs:
+        show_one_conf(hub, cfg)
     hub.line("always-set-cfg: %s" % ("yes" if hub.current.always_setcfg else
                                      "no"))
 
@@ -528,11 +535,25 @@ class DistutilsCfg(BaseCfg):
 class PipCfg(BaseCfg):
     section_name = "[global]"
 
+    def __init__(self, path=None, venv=None):
+        self.venv = venv
+        super(PipCfg, self).__init__(path=path)
+
     @property
     def default_location(self):
-        default_location = ("~/.pip/pip.conf" if sys.platform != "win32"
-                            else "~/pip/pip.ini")
-        return os.environ.get('PIP_CONFIG_FILE', default_location)
+        if self.venv:
+            default_location = py.path.local(self.venv, expanduser=True).join(self.pip_conf_name)
+        elif 'PIP_CONFIG_FILE' in os.environ:
+            default_location = os.environ.get('PIP_CONFIG_FILE')
+        else:
+            confdir = py.path.local("~/.pip" if sys.platform != "win32" else "~/pip",
+                                    expanduser=True)
+            default_location = confdir.join(self.pip_conf_name)
+        return default_location
+
+    @property
+    def pip_conf_name(self):
+        return "pip.conf" if sys.platform != "win32" else "pip.ini"
 
     def write_searchindexserver(self, searchindexserver):
         self.ensure_backup_file()

--- a/client/devpi/use.py
+++ b/client/devpi/use.py
@@ -345,12 +345,12 @@ def getvenv():
 
 def current_venv():
     venv = None
-    if (hasattr(sys, 'real_prefix') or
+    if "VIRTUAL_ENV" in os.environ:
+        venv = os.environ["VIRTUAL_ENV"]
+
+    elif (hasattr(sys, 'real_prefix') or
             (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix)):
         venv = sys.prefix
-
-    elif "VIRTUAL_ENV" in os.environ:
-        venv = os.environ["VIRTUAL_ENV"]
 
     return venv
 

--- a/client/devpi/use.py
+++ b/client/devpi/use.py
@@ -337,12 +337,6 @@ def out_index_list(hub, data):
                      ixconfig["volatile"]))
     return
 
-def getvenv():
-    pip = py.path.local.sysfind("pip")
-    if pip is None:
-        return None
-    return pip.dirpath().dirpath()
-
 def active_venv():
     venv = None
     if "VIRTUAL_ENV" in os.environ:
@@ -376,22 +370,6 @@ def main(hub, args=None):
     if url or current.index:
         current.configure_fromurl(hub, url, client_cert=args.client_cert)
 
-    venvdir = None
-    if args.venv == "-":
-        current.reconfigure(dict(venvdir=None))
-    else:
-        if args.venv:
-            venvname = args.venv
-            cand = hub.cwd.join(venvname, vbin, abs=True)
-            if not cand.check():
-                cand = hub.path_venvbase.join(venvname, vbin)
-                if not cand.check():
-                    hub.fatal("no virtualenv %r found" % venvname)
-            venvdir = cand.dirpath().strpath
-            current.reconfigure(dict(venvdir=venvdir))
-        else:
-            venvdir = current.venvdir or active_venv()
-
     if args.list:
         if not current.rooturl:
             hub.fatal("not connected to any server")
@@ -420,6 +398,8 @@ def main(hub, args=None):
     else:
         hub.line("no server: type 'devpi use URL' with a URL "
                  "pointing to a server or directly to an index.")
+
+    venvdir = hub.venv
     if venvdir:
         hub.info("venv for install/set commands: %s" % venvdir)
 

--- a/client/devpi/use.py
+++ b/client/devpi/use.py
@@ -464,7 +464,7 @@ def show_one_conf(hub, cfg):
         status = cfg.indexserver
     hub.info("%-23s: %s" %(cfg.screen_name, status))
 
-class BaseCfg:
+class BaseCfg(object):
     config_name = "index_url"
     regex = re.compile(r"(index[_-]url)\s*=\s*(.*)")
 

--- a/client/testing/test_install.py
+++ b/client/testing/test_install.py
@@ -1,5 +1,4 @@
 import os
-import py
 import re
 
 

--- a/client/testing/test_use.py
+++ b/client/testing/test_use.py
@@ -355,6 +355,17 @@ class TestUnit:
         hub = cmd_devpi("use", "--venv=yes")
         assert hub.current.venvdir == venvdir
 
+    def test_new_venvsetting(self, out_devpi, cmd_devpi, tmpdir, monkeypatch):
+        venvdir = tmpdir.join('.venv')
+        assert not venvdir.exists()
+        monkeypatch.chdir(tmpdir)
+        hub = cmd_devpi("use", "--venv=%s" % venvdir)
+        current = PersistentCurrent(hub.current.path)
+        assert current.venvdir == str(venvdir)
+        cmd_devpi("use", "--venv=%s" % venvdir)
+        res = out_devpi("use")
+        res.stdout.fnmatch_lines("*venv*%s" % venvdir)
+
     def test_venv_setcfg(self, mock_http_api, cmd_devpi, tmpdir, monkeypatch):
         from devpi.use import vbin
         monkeypatch.setenv("HOME", tmpdir.join('home'))

--- a/client/testing/test_use.py
+++ b/client/testing/test_use.py
@@ -344,9 +344,14 @@ class TestUnit:
         res = out_devpi("use")
         res.stdout.fnmatch_lines("*venv*%s" % venvdir)
 
-        # test via env
+        # test via env for virtualenvwrapper
         monkeypatch.setenv("WORKON_HOME", venvdir.dirpath())
         hub = cmd_devpi("use", "--venv=%s" % venvdir.basename)
+        assert hub.current.venvdir == venvdir
+
+        # test via env for activated venv
+        monkeypatch.setenv("VIRTUAL_ENV", venvdir)
+        hub = cmd_devpi("use", "--venv=yes")
         assert hub.current.venvdir == venvdir
 
     @pytest.mark.parametrize(['scheme', 'basic_auth'], [

--- a/client/testing/test_use.py
+++ b/client/testing/test_use.py
@@ -2,6 +2,7 @@ from devpi.use import BuildoutCfg, DistutilsCfg, PipCfg
 from devpi.use import Current, PersistentCurrent
 from devpi.use import parse_keyvalue_spec, out_index_list
 from devpi_common.url import URL
+import devpi.use
 import pytest
 import re
 import requests.exceptions
@@ -295,7 +296,7 @@ class TestUnit:
                         authstatus=["noauth", ""],
                    ))
 
-        hub = cmd_devpi("use", "http://world/this")
+        hub = cmd_devpi("use", "--venv", "-", "http://world/this")
         newapi = hub.current
         assert newapi.pypisubmit == "http://world/post"
         assert newapi.simpleindex == "http://world/index/"
@@ -403,6 +404,7 @@ class TestUnit:
                             tmpdir.join("dist.cfg"))
         monkeypatch.setattr(BuildoutCfg, "default_location",
                             tmpdir.join("buildout.cfg"))
+        monkeypatch.setattr(devpi.use, "active_venv", lambda: None)
         mock_http_api.set("%s://world/+api" % scheme, 200,
                     result=dict(
                         pypisubmit="",
@@ -445,7 +447,7 @@ class TestUnit:
         hub = cmd_devpi(
             "use", "--set-cfg", "--pip-set-trusted=yes", "%s://%sworld" % (
                 scheme, basic_auth))
-        content = PipCfg.default_location.read()
+        content = PipCfg().default_location.read()
         assert len(
             re.findall("trusted-host\s*=\s*world", content)) == 1
         hub = cmd_devpi("use", "--always-set-cfg=yes", "--pip-set-trusted=yes")

--- a/client/testing/test_use.py
+++ b/client/testing/test_use.py
@@ -341,7 +341,7 @@ class TestUnit:
         hub = cmd_devpi("use", "--venv=%s" % venvdir)
         current = PersistentCurrent(hub.current.path)
         assert current.venvdir == str(venvdir)
-        hub = cmd_devpi("use", "--venv=%s" % venvdir)
+        cmd_devpi("use", "--venv=%s" % venvdir)
         res = out_devpi("use")
         res.stdout.fnmatch_lines("*venv*%s" % venvdir)
 
@@ -376,7 +376,7 @@ class TestUnit:
         venvdir.ensure(vbin, dir=1)
         monkeypatch.chdir(tmpdir)
         index = "http://world/simple"
-        hub = cmd_devpi("use", "--venv=%s" % venvdir, "--set-cfg", index)
+        cmd_devpi("use", "--venv=%s" % venvdir, "--set-cfg", index)
 
         assert not PipCfg().path.exists()
         assert not DistutilsCfg.default_location.exists()
@@ -415,9 +415,9 @@ class TestUnit:
                         authstatus=["noauth", ""],
                    ))
 
-        hub = cmd_devpi("use", "--set-cfg", "%s://%sworld" % (scheme, basic_auth))
+        cmd_devpi("use", "--set-cfg", "%s://%sworld" % (scheme, basic_auth))
         # run twice to find any issues where lines are added more than once
-        hub = cmd_devpi("use", "--set-cfg", "%s://%sworld" % (scheme, basic_auth))
+        cmd_devpi("use", "--set-cfg", "%s://%sworld" % (scheme, basic_auth))
         assert PipCfg().default_location.exists()
         content = PipCfg().default_location.read()
         assert len(
@@ -444,7 +444,7 @@ class TestUnit:
         hub = cmd_devpi("use", "--always-set-cfg=no")
         assert not hub.current.always_setcfg
         # Now set the trusted-host
-        hub = cmd_devpi(
+        cmd_devpi(
             "use", "--set-cfg", "--pip-set-trusted=yes", "%s://%sworld" % (
                 scheme, basic_auth))
         content = PipCfg().default_location.read()

--- a/client/testing/test_use.py
+++ b/client/testing/test_use.py
@@ -2,7 +2,6 @@ from devpi.use import BuildoutCfg, DistutilsCfg, PipCfg
 from devpi.use import Current, PersistentCurrent
 from devpi.use import parse_keyvalue_spec, out_index_list
 from devpi_common.url import URL
-import devpi.use
 import pytest
 import re
 import requests.exceptions


### PR DESCRIPTION
This is a combination/extension of my virtualenv pull requests from bitbucket.

It also includes automatic detection of running from virtualenv and/or running with activated virtualenv and using this for `use`, `install` etc.
As such the previous runtime argument --venv=yes is removed as this is implied now.

The changeset does include the venv handling in --set-cfg in that when operating in a venv only the pip.conf of the venv will be set, not the global settings. There is a line in the output notifying the user as such.

I haven't explicitly tested it yet but I expect it to work with upload as discussed in issue #395

I haven't yet added proper test coverage for the automatic virtualenv handing, I need to look into how venv is currently set up in similar tests.