### PR TITLE
Log exceptions in httpget and provide exception representation as response status message to devpi-client.

### DIFF
--- a/server/devpi_server/extpypi.py
+++ b/server/devpi_server/extpypi.py
@@ -323,7 +323,7 @@ class PyPIStage(BaseStage):
 
             # we don't have an old result and got a non-404 code.
             raise self.UpstreamError("%s status on GET %s" %
-                                     (response.status_code, url))
+                                     (response.status, url))
 
         # pypi.python.org provides X-PYPI-LAST-SERIAL header in case of 200 returns.
         # devpi-master may provide a 200 but not supply the header

--- a/server/devpi_server/main.py
+++ b/server/devpi_server/main.py
@@ -287,6 +287,7 @@ class XOM:
                         timeout=timeout)
             return resp
         except self._httpsession.Errors:
+            threadlog.exception("Error during httpget of %s", url)
             return FatalResponse(sys.exc_info())
 
     def create_app(self):
@@ -391,7 +392,15 @@ class FatalResponse:
     status_code = -1
 
     def __init__(self, excinfo=None):
-        self.excinfo = excinfo
+        self.reason = repr(excinfo[1])
+
+    @property
+    def status(self):
+        return "%s %s" % (self.status_code, self.reason)
+
+    def __repr__(self):
+        return "%s(%r)" % (self.__class__.__name__, self.reason)
+
 
 def get_remote_ip(request):
     return request.headers.get("X-REAL-IP", request.client_addr)

--- a/server/test_devpi_server/conftest.py
+++ b/server/test_devpi_server/conftest.py
@@ -316,6 +316,11 @@ def httpget(pypiurls):
                     xself.allow_redirects = allow_redirects
                     if "content" in fakeresponse:
                         xself.raw = py.io.BytesIO(fakeresponse["content"])
+
+                @property
+                def status(xself):
+                    return "%s" % xself.status_code
+
                 def __repr__(xself):
                     return "<mockresponse %s url=%s>" % (xself.status_code,
                                                          xself.url)


### PR DESCRIPTION
See #404 