### PR TITLE
unquoting URL path for basenames

### DIFF
--- a/common/devpi_common/url.py
+++ b/common/devpi_common/url.py
@@ -1,13 +1,14 @@
-
 import sys
 import posixpath
 from devpi_common.types import cached_property, ensure_unicode, parse_hash_spec
 from requests.models import parse_url
 
 if sys.version_info >= (3, 0):
-    from urllib.parse import urlparse, urlunsplit, urljoin
+    from urllib.parse import urlparse, urlunsplit, urljoin, unquote
 else:
     from urlparse import urlparse, urlunsplit, urljoin
+    from urllib import unqote
+
 
 def _joinpath(url, args, asdir=False):
     new = url
@@ -17,6 +18,7 @@ def _joinpath(url, args, asdir=False):
     if asdir:
         new = new.rstrip("/") + "/"
     return new
+
 
 class URL:
     def __init__(self, url="", *args, **kwargs):
@@ -121,11 +123,11 @@ class URL:
 
     @property
     def basename(self):
-        return posixpath.basename(self._parsed.path)
+        return posixpath.basename(unqote(self._parsed.path))
 
     @property
     def parentbasename(self):
-        return posixpath.basename(posixpath.dirname(self._parsed.path))
+        return posixpath.basename(posixpath.dirname(unqote(self._parsed.path)))
 
     @property
     def eggfragment(self):
@@ -193,4 +195,3 @@ class URL:
         """ return url from canonical relative path. """
         scheme, netlocpath = relpath.split("/", 1)
         return cls(scheme + "://" + netlocpath)
-

--- a/common/devpi_common/url.py
+++ b/common/devpi_common/url.py
@@ -7,7 +7,7 @@ if sys.version_info >= (3, 0):
     from urllib.parse import urlparse, urlunsplit, urljoin, unquote
 else:
     from urlparse import urlparse, urlunsplit, urljoin
-    from urllib import unqote
+    from urllib import unquote
 
 
 def _joinpath(url, args, asdir=False):
@@ -123,11 +123,11 @@ class URL:
 
     @property
     def basename(self):
-        return posixpath.basename(unqote(self._parsed.path))
+        return posixpath.basename(unquote(self._parsed.path))
 
     @property
     def parentbasename(self):
-        return posixpath.basename(posixpath.dirname(unqote(self._parsed.path)))
+        return posixpath.basename(posixpath.dirname(unquote(self._parsed.path)))
 
     @property
     def eggfragment(self):


### PR DESCRIPTION
Solves problem with quoted `+` and `!` in path names. 

Both characters are compliant with PEP440 version specifiers, `!` is used as epoch separator, `+` is used as local version part separator. 

Currently if you try to download `package-1.2.3+vendor`, your saving `package-1.2.3%2Bvendor` file to the disk, which later results in `file not found`. 