### PR TITLE
Decode URL encoded paths while saving packages

### DIFF
--- a/common/devpi_common/url.py
+++ b/common/devpi_common/url.py
@@ -1,13 +1,14 @@
-
 import sys
 import posixpath
 from devpi_common.types import cached_property, ensure_unicode, parse_hash_spec
 from requests.models import parse_url
 
 if sys.version_info >= (3, 0):
-    from urllib.parse import urlparse, urlunsplit, urljoin
+    from urllib.parse import urlparse, urlunsplit, urljoin, unquote
 else:
     from urlparse import urlparse, urlunsplit, urljoin
+    from urllib import unquote
+
 
 def _joinpath(url, args, asdir=False):
     new = url
@@ -17,6 +18,7 @@ def _joinpath(url, args, asdir=False):
     if asdir:
         new = new.rstrip("/") + "/"
     return new
+
 
 class URL:
     def __init__(self, url="", *args, **kwargs):
@@ -121,11 +123,11 @@ class URL:
 
     @property
     def basename(self):
-        return posixpath.basename(self._parsed.path)
+        return posixpath.basename(unquote(self._parsed.path))
 
     @property
     def parentbasename(self):
-        return posixpath.basename(posixpath.dirname(self._parsed.path))
+        return posixpath.basename(posixpath.dirname(unquote(self._parsed.path)))
 
     @property
     def eggfragment(self):
@@ -193,4 +195,3 @@ class URL:
         """ return url from canonical relative path. """
         scheme, netlocpath = relpath.split("/", 1)
         return cls(scheme + "://" + netlocpath)
-

--- a/server/devpi_server/filestore.py
+++ b/server/devpi_server/filestore.py
@@ -10,8 +10,15 @@ from wsgiref.handlers import format_date_time
 import os
 import py
 import re
+import sys
 from devpi_common.types import cached_property, parse_hash_spec
 from .log import threadlog
+
+
+if sys.version_info >= (3, 0):
+    from urllib.parse import unquote
+else:
+    from urllib import unquote
 
 log = threadlog
 _nodefault = object()
@@ -57,8 +64,8 @@ class FileStore:
             dirname = re.sub('[^a-zA-Z0-9_.-]', '_', dirname)
             key = self.keyfs.PYPIFILE_NOMD5(
                 user=user, index=index,
-                dirname=dirname,
-                basename=parts[-1])
+                dirname=unquote(dirname),
+                basename=unquote(parts[-1]))
         entry = FileEntry(self.xom, key, readonly=False)
         entry.url = link.geturl_nofragment().url
         entry.eggfragment = link.eggfragment

--- a/server/news/425.bugfix
+++ b/server/news/425.bugfix
@@ -1,0 +1,4 @@
+fix for url decoding issue with mirrors.
+
+When package filenames contain characters such as `!` or `+`, these get URL encoded to `%21` and `%2B`
+in the remote simple index. This fix ensures that in the filename saved to the disk cache these are decoded back to `!` or `+`.

--- a/server/test_devpi_server/functional.py
+++ b/server/test_devpi_server/functional.py
@@ -1,5 +1,9 @@
 import pytest
 
+try:
+    from urllib import quote as url_quote
+except ImportError:
+    from urllib.parse import quote as url_quote
 
 class API:
     def __init__(self, d):
@@ -435,3 +439,19 @@ class TestMirrorIndexThings:
         mapp.upload_file_pypi("pkg-1.0.tar.gz", content, "pkg", "1.0")
         r = mapp.get_simple("pkg")
         assert b'ed7/002b439e9ac84/pkg-1.0.tar.gz' in r.body
+
+    def test_releases_urlquoting(self, mapp, simpypi):
+        mapp.create_and_login_user('mirror9')
+        indexconfig = dict(
+            type="mirror",
+            mirror_url=simpypi.simpleurl,
+            mirror_cache_expiry=0)
+        mapp.create_index("mirror", indexconfig=indexconfig)
+        mapp.use("mirror9/mirror")
+        url_quoted_pkgver = url_quote('pkg-1!2017.4+devpi.zip')
+        assert url_quoted_pkgver == 'pkg-1%212017.4%2Bdevpi.zip'
+        simpypi.add_release('pkg', pkgver=url_quoted_pkgver)
+        result = mapp.getreleaseslist("pkg")
+        base = simpypi.baseurl.replace('http://', 'http_').replace(':', '_')
+        assert len(result) == 1
+        assert result[0].endswith('/mirror9/mirror/+e/%s_pkg/pkg-1!2017.4+devpi.zip' % base)


### PR DESCRIPTION
As of now devpi server does not decode the path component of the URL before using it as file path.

This causes problems with characters that are valid in package name, but do get quoted (! and + are the ones I stumbled upon, both are valid characters in version specifier per PEP440).

Before the fix:

```reading remote: https://host/foo-1.2.3%2Bvendor-py2-none-any.whl, target root/a_mirror/+e/host/foo-1.2.3%2Bvendor-py2-none-any.whl```

Saving as `foo-1.2.3%2Bvendor-py2-none-any.whl` was subsequently causing file not found error when trying to access `foo-1.2.3+vendor-py2-none-any.whl`

After the fix:
```reading remote: https://host/foo-1.2.3%2Bvendor-py2-none-any.whl, target root/a_mirror/+e/host/foo-1.2.3+vendor-py2-none-any.whl```
