### PR TITLE
HTML doesn't have a ``PUSH`` method, replace it with ``POST``.

### DIFF
--- a/server/devpi_server/views.py
+++ b/server/devpi_server/views.py
@@ -567,7 +567,7 @@ class PyPIView:
         stage.delete()
         apireturn(201, "index %s deleted" % stage.name)
 
-    @view_config(route_name="/{user}/{index}", request_method="PUSH")
+    @view_config(route_name="/{user}/{index}", request_method=("POST", "PUSH"))
     def pushrelease(self):
         request = self.request
         stage = self.context.stage

--- a/server/test_devpi_server/conftest.py
+++ b/server/test_devpi_server/conftest.py
@@ -803,7 +803,7 @@ class MyTestApp(TApp):
 
     def push(self, url, params=None, **kw):
         kw.setdefault("expect_errors", True)
-        return self._gen_request("PUSH", url, params=params, **kw)
+        return self._gen_request("POST", url, params=params, **kw)
 
     def get(self, *args, **kwargs):
         kwargs.setdefault("expect_errors", True)

--- a/server/test_devpi_server/test_views.py
+++ b/server/test_devpi_server/test_views.py
@@ -1184,7 +1184,7 @@ def test_upload_and_push_external(mapp, testapp, reqmock):
                username="user", password="password")
     rec = reqmock.mockresponse(url=None, code=200, method="POST", data="msg")
     body = json.dumps(req).encode("utf-8")
-    r = testapp.request(api.index, method="PUSH", body=body,
+    r = testapp.request(api.index, method="POST", body=body,
                         expect_errors=True)
     assert r.status_code == 200
     assert len(rec.requests) == 3
@@ -1197,7 +1197,7 @@ def test_upload_and_push_external(mapp, testapp, reqmock):
 
     # push with error
     reqmock.mockresponse(url=None, code=500, method="POST")
-    r = testapp.request(api.index, method="PUSH", body=body, expect_errors=True)
+    r = testapp.request(api.index, method="POST", body=body, expect_errors=True)
     assert r.status_code == 502
     result = r.json["result"]
     assert len(result) == 1
@@ -1248,7 +1248,7 @@ def test_upload_and_push_warehouse(mapp, testapp, reqmock):
     req = dict(name="pkg1", version="2.6", posturl="http://whatever.com/",
                username="user", password="password")
     body = json.dumps(req).encode("utf-8")
-    r = testapp.request(api.index, method="PUSH", body=body,
+    r = testapp.request(api.index, method="POST", body=body,
                         expect_errors=True)
     assert r.status_code == 200
     assert len(requests) == 3


### PR DESCRIPTION
For backward compatibility we still need to support ``PUSH`` though. But this fixes warnings in tests.