### PR TITLE
Fix issue 449 by only using 410 status code as valid when trying to register a package.

### DIFF
--- a/server/devpi_server/views.py
+++ b/server/devpi_server/views.py
@@ -631,10 +631,8 @@ class PyPIView:
             r = session.post(posturl, data=metadata, auth=pypiauth)
             self.log.debug("register returned: %s", r.status_code)
             results.append((r.status_code, "register", name, version))
-            ok_codes = (200, 201)
-            proceed = (
-                (r.status_code in ok_codes) or
-                (r.status_code == 410 and 'simply upload' in r.reason))
+            ok_codes = (200, 201, 410)
+            proceed = (r.status_code in ok_codes)
             if proceed:
                 for link in links["releasefile"]:
                     entry = link.entry

--- a/server/news/449.bugfix
+++ b/server/news/449.bugfix
@@ -1,0 +1,1 @@
+fix issue449: push to pypi broke again due to a changed reply.

--- a/server/test_devpi_server/test_views.py
+++ b/server/test_devpi_server/test_views.py
@@ -1228,7 +1228,7 @@ def test_upload_and_push_warehouse(mapp, testapp, reqmock):
         HTTPResponse(
             body=py.io.BytesIO(b"msg"),
             status=410, preload_content=False,
-            reason="This API is no longer supported, instead simply upload the file."),
+            reason="Project pre-registration is no longer required or supported, so continue directly to uploading files."),
         HTTPResponse(
             body=py.io.BytesIO(b"msg"),
             status=200, preload_content=False),


### PR DESCRIPTION
PyPI changed the text for the 410 reply, which caused pushes to fail again.