### PR TITLE
Fix issue434: ``--status`` didn't work anymore.

### DIFF
--- a/server/devpi_server/config.py
+++ b/server/devpi_server/config.py
@@ -195,7 +195,9 @@ def addoptions(parser, pluginmanager):
                  "index and documentation will gradually update until the "
                  "server has caught up with all events.")
 
-    bg = parser.addgroup("background server")
+    bg = parser.addgroup(
+        "background server (DEPRECATED, see --gen-config to use a process "
+        "manager from your OS)")
     bg.addoption("--start", action="store_true",
             help="start the background devpi-server")
     bg.addoption("--stop", action="store_true",

--- a/server/devpi_server/vendor/xprocess.py
+++ b/server/devpi_server/vendor/xprocess.py
@@ -1,3 +1,4 @@
+import errno
 import sys
 import os
 import py
@@ -73,7 +74,11 @@ class XProcessInfo:
                 return self._isrunning_win32(self.pid)
             try:
                 os.kill(self.pid, 0)
-                os.waitpid(self.pid, os.WNOHANG)
+                try:
+                    os.waitpid(self.pid, os.WNOHANG)
+                except OSError as exc:
+                    if exc.errno != errno.ECHILD:
+                        raise
                 return True
             except OSError:
                 pass

--- a/server/news/434.bugfix
+++ b/server/news/434.bugfix
@@ -1,0 +1,2 @@
+fix issue434: ``--status`` didn't work anymore.
+The background server functionality is now deprecated, see --gen-config to use a process manager from your OS.


### PR DESCRIPTION
The background server functionality is now deprecated, see --gen-config to use a process manager from your OS.