### PR TITLE
devpi-server: Do not install tests

### DIFF
--- a/server/setup.py
+++ b/server/setup.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
       version='4.3.1rc1',
       maintainer="Holger Krekel, Florian Schulze",
       maintainer_email="holger@merlinux.eu",
-      packages=find_packages(),
+      packages=find_packages(exclude=["test_*"]),
       include_package_data=True,
       zip_safe=False,
       license="MIT",


### PR DESCRIPTION
I am currently packaging devpi-server for Gentoo Linux and noticed that setup.py installs the tests into site-packages.

This PR simply excludes the test folder from find_packages, so that they will not be installed.