### PR TITLE
480 additional metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
   - "3.6"
   - "nightly"
   - "pypy-5.4.1"
-  - "pypy3.3-5.2-alpha1"
+#  - "pypy3.3-5.2-alpha1"
 env:
   - PROJECT=client
   - PROJECT=common

--- a/postgresql/tox.ini
+++ b/postgresql/tox.ini
@@ -11,7 +11,6 @@ deps =
     webtest
     mock
     pytest
-    pytest-catchlog
     pytest-flakes
     pytest-pep8
     -e

--- a/server/devpi_server/model.py
+++ b/server/devpi_server/model.py
@@ -576,17 +576,24 @@ class BaseStage(object):
 
 class PrivateStage(BaseStage):
 
-    metadata_keys = """
-        name version summary home_page author author_email
-        license description keywords platform classifiers download_url
-    """.split()
-    # taken from distlib.metadata (6th October)
-    metadata_list_fields = ('platform', 'classifier', 'classifiers',
-               'obsoletes',
-               'requires', 'provides', 'obsoletes-Dist',
-               'provides-dist', 'requires-dist', 'requires-external',
-               'project-url', 'supported-platform', 'setup-requires-Dist',
-               'provides-extra', 'extension')
+    metadata_keys = (
+        'name', 'version',
+        # additional meta-data
+        'metadata_version', 'summary', 'home_page', 'author', 'author_email',
+        'maintainer', 'maintainer_email', 'license', 'description',
+        'keywords', 'platform', 'classifiers', 'download_url',
+        'supported_platform', 'comment',
+        # PEP 314
+        'provides', 'requires', 'obsoletes',
+        # Metadata 1.2
+        'project_urls', 'provides_dist', 'obsoletes_dist',
+        'requires_dist', 'requires_external', 'requires_python')
+    metadata_list_fields = (
+        'platform', 'classifiers', 'obsoletes',
+        'requires', 'provides', 'obsoletes_dist',
+        'provides_dist', 'requires_dist', 'requires_external',
+        'project_url', 'supported_platform', 'setup_requires_dist',
+        'provides_extra', 'extension')
 
     def __init__(self, xom, username, index, ixconfig):
         super(PrivateStage, self).__init__(xom, username, index, ixconfig)

--- a/server/news/480.bugfix
+++ b/server/news/480.bugfix
@@ -1,0 +1,1 @@
+fix issue480: store additional metadata for packages.

--- a/server/test_devpi_server/test_streaming.py
+++ b/server/test_devpi_server/test_streaming.py
@@ -5,9 +5,11 @@ import requests
 import sys
 
 
-pytestmark = pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="issues with process management on Windows")
+pytestmark = [
+    pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="issues with process management on Windows"),
+    pytest.mark.skipif("not config.option.slow")]
 
 
 @pytest.fixture

--- a/server/tox.ini
+++ b/server/tox.ini
@@ -14,7 +14,6 @@ deps=
     webtest
     py27,pypy: mock
     pytest>=3
-    pytest-catchlog
     pytest-flakes
     pytest-timeout
     beautifulsoup4


### PR DESCRIPTION
This should fix #480 and further instances of https://github.com/pytest-dev/pytest/issues/2966 by storing the additional metadata.

I tested "push" from one devpi to another and the new metadata is transferred.

Uploads with "devpi upload" and "twine upload" also store the metadata properly now with no additional fixes.

@jaraco @nicoddemus @RonnyPfannschmidt @takluyver

If this looks good, I will update devpi.net to use a prerelease for further testing.