### PR TITLE
Properly set up HTTP basic auth during `devpi test`

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -17,7 +17,7 @@ Pull Requests
 - If you are unsure on how to write a test, please ask and we will point you to
   existing tests which should help you writing new ones.
 - Embrace ``git rebase`` to create "nice" commits and history.
-- We strife for PEP8 compliance. New code should comply, old code must only
+- We strive for PEP8 compliance. New code should comply, old code must only
   comply when it's changed anyway. No unnecessary cleanups which would only
   make the PR harder to read.
 - Add a changelog entry in the ``news`` folder of touched packages as a new file.

--- a/client/devpi/test.py
+++ b/client/devpi/test.py
@@ -40,7 +40,9 @@ class DevIndex:
 
     def download_and_unpack(self, versioninfo, link):
         url = link.href
-        r = self.hub.http.get(url)
+        r = self.hub.http.get(url,
+                              auth=self.hub.current.get_basic_auth(url),
+                              cert=self.hub.current.get_client_cert(url))
         if r.status_code != 200:
             self.hub.fatal("could not receive", url)
         content = r.content
@@ -77,7 +79,7 @@ class DevIndex:
         jsonreport = pkg.rootdir.join("toxreport.json")
         path_archive = pkg.path_archive
         toxargs = ["--installpkg", str(path_archive),
-                   "-i ALL=%s" % str(self.current.simpleindex),
+                   "-i ALL=%s" % str(self.current.simpleindex_auth),
                    "--recreate",
                    "--result-json", str(jsonreport),
         ]

--- a/client/devpi/test.py
+++ b/client/devpi/test.py
@@ -78,18 +78,24 @@ class DevIndex:
     def runtox(self, link, pkg, sdist_pkg=None, upload_tox_results=True):
         jsonreport = pkg.rootdir.join("toxreport.json")
         path_archive = pkg.path_archive
-        toxargs = ["--installpkg", str(path_archive),
-                   "-i ALL=%s" % str(self.current.simpleindex_auth),
-                   "--recreate",
-                   "--result-json", str(jsonreport),
+        toxargs = [
+            "--installpkg", str(path_archive),
+            "-i ALL=%s" % str(self.current.simpleindex_auth),
+            "--recreate",
+            "--result-json", str(jsonreport),
         ]
+        if self.current.simpleindex != self.current.simpleindex_auth:
+            self.hub.info("Using existing basic auth for '%s'." %
+                          self.current.simpleindex)
+            self.hub.warn("The password will be available unencrypted in the "
+                          "JSON report!")
 
         if sdist_pkg is None:
             sdist_pkg = pkg
         toxargs.extend(self.get_tox_args(unpack_path=sdist_pkg.path_unpacked))
 
         with sdist_pkg.path_unpacked.as_cwd():
-            self.hub.info("%s$ tox %s" %(os.getcwd(), " ".join(toxargs)))
+            self.hub.info("%s$ tox %s" % (os.getcwd(), " ".join(toxargs)))
             toxrunner = self.get_tox_runner()
             try:
                 ret = toxrunner(toxargs)

--- a/client/news/test-with-basic-auth.bugfix
+++ b/client/news/test-with-basic-auth.bugfix
@@ -1,0 +1,2 @@
+devpi test: if basic auth is configured, correctly pass credentials when downloading packages and submitting JSON reports.
+Thanks to Vytautas Liuolia for the PR.


### PR DESCRIPTION
 * Use basic auth when downloading packages
 * Pass basic auth-enabled Pip index to tox