### PR TITLE
Fix issue496: PyPy 5.10 wheel upload failed

### DIFF
--- a/common/devpi_common/metadata.py
+++ b/common/devpi_common/metadata.py
@@ -69,7 +69,6 @@ def get_pyversion_filetype(basename):
         pyversion = "2.7"  # arbitrary but pypi/devpi makes no special use
                            # of "pyversion" anyway?!
     elif "." not in pyversion:
-        assert len(pyversion) in (1, 2, 3)  # TODO: do we really care?
         pyversion = ".".join(pyversion)
     return (pyversion, _ext2type[ext])
 

--- a/common/news/496.bugfix
+++ b/common/news/496.bugfix
@@ -1,0 +1,1 @@
+fix issue496: PyPy 5.10 wheel upload failed because the version in the filename is longer again, the check for it is now removed, because it's pointless.

--- a/common/testing/test_metadata.py
+++ b/common/testing/test_metadata.py
@@ -28,6 +28,7 @@ from devpi_common.metadata import *
     ("my-binary-package-name-1-4-3-yip-0.9.tar.gz", ("my-binary-package-name-1-4-3-yip", "0.9", ".tar.gz")),
     ("my-binary-package-name-1-4-3-yip-0.9+deadbeef.tar.gz", ("my-binary-package-name-1-4-3-yip", "0.9+deadbeef", ".tar.gz")),
     ("cffi-1.6.0-pp251-pypy_41-macosx_10_11_x86_64.whl", ("cffi", "1.6.0", "-pp251-pypy_41-macosx_10_11_x86_64.whl")),
+    ("argon2_cffi-18.2.0.dev0.0-pp2510-pypy_41-macosx_10_13_x86_64.whl", ("argon2_cffi", "18.2.0.dev0.0", "-pp2510-pypy_41-macosx_10_13_x86_64.whl")),
 ])
 def test_splitbasename(releasename, expected):
     result = splitbasename(releasename)
@@ -42,7 +43,8 @@ def test_splitbasename(releasename, expected):
     ("greenlet-0.4.0-py3.3-win-amd64.egg", ("3.3", "bdist_egg")),
     ("greenlet-0.4.0.linux-x86_64.tar.gz", ("any", "bdist_dumb")),
     ("cffi-1.6.0-pp251-pypy_41-macosx_10_11_x86_64.whl", ("2.5.1", "bdist_wheel")),
-    ("cryptography-1.4-pp253-pypy_41-linux_x86_64.whl", ("2.5.3", "bdist_wheel"))
+    ("cryptography-1.4-pp253-pypy_41-linux_x86_64.whl", ("2.5.3", "bdist_wheel")),
+    ("argon2_cffi-18.2.0.dev0.0-pp2510-pypy_41-macosx_10_13_x86_64.whl", ("2.5.1.0", "bdist_wheel")),
 ])
 def test_get_pyversion_filetype(releasename, expected):
     result = get_pyversion_filetype(releasename)


### PR DESCRIPTION
Fix issue496: PyPy 5.10 wheel upload failed because the version in the filename is longer again, the check for it is now removed, because it's pointless.

The extracted version string isn't correct (2.5.1.0 instead of 2.5.10) but it's not really used anyway besides as additional info in devpi-web.

This replaces PR #497 

cc @WolverineFan