### PR TITLE
Adjust minimal Pyramid version regarding safe URL path segments

### DIFF
--- a/server/news/430.bugfix
+++ b/server/news/430.bugfix
@@ -1,0 +1,1 @@
+adjust minimum version of pyramid to 1.8 (related to #430)

--- a/server/setup.py
+++ b/server/setup.py
@@ -26,7 +26,7 @@ if __name__ == "__main__":
                         "devpi_common<4,>=3.2.0rc1",
                         "itsdangerous>=0.24",
                         "execnet>=1.2",
-                        "pyramid>=1.5.1",
+                        "pyramid>=1.8",
                         "waitress>=1.0.1",
                         "repoze.lru>=0.6",
                         "passlib[argon2]",


### PR DESCRIPTION
I've been slowly working through the Debian packaging of devpi. We currently ship pyramid 1.6. Unfortunately, the --slow tests related to urlencoded packages fail with this Pyramid version.

I've managed to track down the issue to a specific commit in Pyramid: https://github.com/Pylons/pyramid/commit/f52759bf3149e197481c954ae94cc04e5555f9ba adds + and ! to the safe path segments.

This PR adjusts the minimum pyramid version for the devpi server.

.oO(now, I get to update Pyramid in Debian, yay)