### PR TITLE
Adjustable request timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,4 +69,5 @@ ENV/
 /.hg/
 /etc/
 /tmp/
-
+*.sw[po]
+**/tags

--- a/doc/userman/devpi_commands.rst
+++ b/doc/userman/devpi_commands.rst
@@ -546,6 +546,9 @@ devpi command reference (server)
       --replica-max-retries NUM
                             Number of retry attempts for replica connection
                             failures (such as aborted connections to pypi).
+      --request-timeout     NUM
+                            Number of seconds before request being terminated
+                            (such as connections to pypi, etc.). [30]
       --offline-mode        (experimental) prevents connections to any upstream
                             server (e.g. pypi) and only serves locally cached
                             files through the simple index used by pip.

--- a/server/devpi_server/config.py
+++ b/server/devpi_server/config.py
@@ -78,6 +78,11 @@ def addoptions(parser, pluginmanager):
             help="Number of retry attempts for replica connection failures "
                  "(such as aborted connections to pypi).")
 
+    mirror.addoption("--request-timeout", type=int, metavar="NUM",
+            default=30,
+            help="Number of seconds before request being terminated "
+                 "(such as connections to pypi, etc.).")
+
     mirror.addoption("--offline-mode", action="store_true",
             help="(experimental) prevents connections to any upstream server "
                  "(e.g. pypi) and only serves locally cached files through the "

--- a/server/devpi_server/main.py
+++ b/server/devpi_server/main.py
@@ -271,7 +271,7 @@ class XOM:
     def _httpsession(self):
         return self.new_http_session("server", max_retries=self.config.args.replica_max_retries)
 
-    def httpget(self, url, allow_redirects, timeout=30, extra_headers=None):
+    def httpget(self, url, allow_redirects, timeout=None, extra_headers=None):
         if self.config.args.offline_mode:
             resp = Response()
             resp.status_code = 503  # service unavailable
@@ -284,7 +284,7 @@ class XOM:
                         url, stream=True,
                         allow_redirects=allow_redirects,
                         headers=headers,
-                        timeout=timeout)
+                        timeout=timeout or self.config.args.request_timeout)
             return resp
         except self._httpsession.Errors:
             threadlog.exception("Error during httpget of %s", url)

--- a/server/news/request_timeout.feature
+++ b/server/news/request_timeout.feature
@@ -1,0 +1,1 @@
+add `--request-timeout` option to provide adjustable request timeout

--- a/server/test_devpi_server/test_main.py
+++ b/server/test_devpi_server/test_main.py
@@ -182,6 +182,22 @@ def test_replica_max_retries_option(makexom, monkeypatch):
                               timeout=1.2)
     assert r.status_code == -1
 
+
+@pytest.mark.nomocking
+@pytest.mark.parametrize("input_set", [
+    {'timeout': 30, 'arg': [], 'kwarg': None},
+    {'timeout': 42, 'arg': ["--request-timeout=42"], 'kwarg': None},
+    {'timeout': 123, 'arg': [], 'kwarg': 123}
+])
+def test_request_args_timeout_handover(makexom, input_set):
+    def mock_http_get(*args, **kwargs):
+        assert kwargs["timeout"] == input_set['timeout']
+    xom = makexom(input_set['arg'])
+    xom._httpsession.get = mock_http_get
+
+    xom.httpget("http://whatever", allow_redirects=False, timeout=input_set['kwarg'])
+
+
 def test_no_root_pypi_option(makexom):
     xom = makexom(["--no-root-pypi"])
     with xom.keyfs.transaction(write=False):


### PR DESCRIPTION
Hi!

This PR provides a way to adjust default request timeout, since waiting 30s x 4 times retry takes forever to timeout. New optional mirror arg has been added `--request-timeout` which defaults to 30 seconds when not specified, so this change shouldn't break anything.

I've updated news, docs and wrote some tests. Is there anything more to be done? 😄 