### PR TITLE
Fix exception when raising exception

### DIFF
--- a/server/devpi_server/extpypi.py
+++ b/server/devpi_server/extpypi.py
@@ -323,7 +323,7 @@ class PyPIStage(BaseStage):
 
             # we don't have an old result and got a non-404 code.
             raise self.UpstreamError("%s status on GET %s" %
-                                     (response.status, url))
+                                     (response.status_code, url))
 
         # pypi.org provides X-PYPI-LAST-SERIAL header in case of 200 returns.
         # devpi-master may provide a 200 but not supply the header

--- a/server/news/fix-upstream-raise.bugfix
+++ b/server/news/fix-upstream-raise.bugfix
@@ -1,0 +1,1 @@
+fix raising of UpstreamError by using correct ``status_code`` attribute of response instead of not existing ``status``.

--- a/server/test_devpi_server/conftest.py
+++ b/server/test_devpi_server/conftest.py
@@ -323,10 +323,6 @@ def httpget(pypiurls):
                     if "content" in fakeresponse:
                         xself.raw = py.io.BytesIO(fakeresponse["content"])
 
-                @property
-                def status(xself):
-                    return "%s" % xself.status_code
-
                 def __repr__(xself):
                     return "<mockresponse %s url=%s>" % (xself.status_code,
                                                          xself.url)


### PR DESCRIPTION
`response.status` does not exist so it raises an exception while trying to raise a different exception (effectively hiding the real cause of the exception).