### PR TITLE
Fix #549: reduce timeout for requests to PyPI etc from 30 to 5 seconds.

### DIFF
--- a/doc/userman/devpi_commands.rst
+++ b/doc/userman/devpi_commands.rst
@@ -548,7 +548,7 @@ devpi command reference (server)
                             failures (such as aborted connections to pypi).
       --request-timeout     NUM
                             Number of seconds before request being terminated
-                            (such as connections to pypi, etc.). [30]
+                            (such as connections to pypi, etc.). [5]
       --offline-mode        (experimental) prevents connections to any upstream
                             server (e.g. pypi) and only serves locally cached
                             files through the simple index used by pip.

--- a/server/devpi_server/config.py
+++ b/server/devpi_server/config.py
@@ -79,7 +79,7 @@ def addoptions(parser, pluginmanager):
                  "(such as aborted connections to pypi).")
 
     mirror.addoption("--request-timeout", type=int, metavar="NUM",
-            default=30,
+            default=5,
             help="Number of seconds before request being terminated "
                  "(such as connections to pypi, etc.).")
 

--- a/server/news/549.bugfix
+++ b/server/news/549.bugfix
@@ -1,0 +1,2 @@
+fix #549: reduce timeout for requests to PyPI etc from 30 to 5 seconds.
+This can be changed with the ``--request-timeout`` option.

--- a/server/test_devpi_server/test_main.py
+++ b/server/test_devpi_server/test_main.py
@@ -185,7 +185,7 @@ def test_replica_max_retries_option(makexom, monkeypatch):
 
 @pytest.mark.nomocking
 @pytest.mark.parametrize("input_set", [
-    {'timeout': 30, 'arg': [], 'kwarg': None},
+    {'timeout': 5, 'arg': [], 'kwarg': None},
     {'timeout': 42, 'arg': ["--request-timeout=42"], 'kwarg': None},
     {'timeout': 123, 'arg': [], 'kwarg': 123}
 ])


### PR DESCRIPTION
This can be changed with the ``--request-timeout`` option.