### PR TITLE
Implement #535: Generate absolute URLs on project simple index pages …

### DIFF
--- a/server/devpi_server/__init__.py
+++ b/server/devpi_server/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '4.5.1.dev0'
+__version__ = '4.6.0.dev0'

--- a/server/devpi_server/config.py
+++ b/server/devpi_server/config.py
@@ -58,6 +58,10 @@ def addoptions(parser, pluginmanager):
                  "and the web server does not set or you want to override "
                  "the custom X-outside-url header.")
 
+    web.addoption("--absolute-urls", action="store_true",
+            help="use absolute URLs everywhere. "
+                 "This will become the default at some point.")
+
     web.addoption("--debug", action="store_true",
             help="run wsgi application with debug logging")
 

--- a/server/devpi_server/views.py
+++ b/server/devpi_server/views.py
@@ -395,6 +395,14 @@ class PyPIView:
     # index serving and upload
     #
 
+    @property
+    def _use_absolute_urls(self):
+        if self.xom.config.args.absolute_urls:
+            return True
+        if 'HTTP_X_DEVPI_ABSOLUTE_URLS' in self.request.environ:
+            return True
+        return False
+
     @view_config(route_name="/{user}/{index}/+simple/{project}")
     def simple_list_project_redirect(self):
         """
@@ -462,11 +470,21 @@ class PyPIView:
                    "<strong>%s</strong> are included.</p>"
                    % blocked_index).encode('utf-8')
 
-        url = URL(self.request.path_info)
+        if self._use_absolute_urls:
+            application_url = self.request.application_url
+            if not application_url.endswith("/"):
+                application_url = application_url + "/"
+            url = URL(application_url)
+            def make_url(href):
+                return url.joinpath(href).url
+        else:
+            url = URL(self.request.path_info)
+            def make_url(href):
+                return url.relpath("/" + href)
         for key, href in result:
             yield ('%s <a href="%s">%s</a><br/>\n' %
                    ("/".join(href.split("/", 2)[:2]),
-                    url.relpath("/" + href),
+                    make_url(href),
                     key)).encode("utf-8")
 
         yield "</body></html>".encode("utf-8")

--- a/server/devpi_server/views.py
+++ b/server/devpi_server/views.py
@@ -471,16 +471,21 @@ class PyPIView:
                    % blocked_index).encode('utf-8')
 
         if self._use_absolute_urls:
+            # for joinpath we need the root url
             application_url = self.request.application_url
             if not application_url.endswith("/"):
                 application_url = application_url + "/"
             url = URL(application_url)
+
             def make_url(href):
                 return url.joinpath(href).url
         else:
+            # for relpath we need the path of the current page
             url = URL(self.request.path_info)
+
             def make_url(href):
                 return url.relpath("/" + href)
+
         for key, href in result:
             yield ('%s <a href="%s">%s</a><br/>\n' %
                    ("/".join(href.split("/", 2)[:2]),

--- a/server/news/535.feature
+++ b/server/news/535.feature
@@ -1,0 +1,1 @@
+implement #535: Generate absolute URLs on project simple index pages when ``--absolute-urls`` option is used or ``X-DEVPI-ABSOLUTE-URLS`` header is set.

--- a/server/setup.py
+++ b/server/setup.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
       keywords="pypi realtime cache server",
       long_description="\n\n".join([README, CHANGELOG]),
       url="http://doc.devpi.net",
-      version='4.5.1.dev0',
+      version='4.6.0.dev0',
       maintainer="Holger Krekel, Florian Schulze",
       maintainer_email="holger@merlinux.eu",
       packages=find_packages(),

--- a/server/test_devpi_server/test_views.py
+++ b/server/test_devpi_server/test_views.py
@@ -168,6 +168,8 @@ def test_simple_project_absolute_url(mapp, pypistage, testapp):
         'http://localhost/root/pypi/+e/https_pypi.org/qpwoei-1.0.zip',
         'http://localhost/user1/dev/+f/%s/qpwoei-1.0.tar.gz#%s' % (hashdir, hash_spec)]
     testapp.xget(200, links[1], headers=headers)
+    # we also test in combination with X-outside-url where devpi is "mounted"
+    # in a sub path
     headers.update({str('X-outside-url'): str("http://localhost/devpi")})
     r = testapp.get("/%s/+simple/qpwoei/" % api.stagename, headers=headers)
     assert r.status_code == 200

--- a/server/test_devpi_server/test_views.py
+++ b/server/test_devpi_server/test_views.py
@@ -145,8 +145,43 @@ def test_simple_project_outside_url_subpath(mapp, outside_url, pypistage, testap
     assert links == [
         '../../+f/%s/qpwoei-1.0.tar.gz#%s' % (hashdir, hash_spec),
         '../../../../root/pypi/+e/https_pypi.org/qpwoei-1.0.zip']
+    # the internal url is always without the "devpi" part, as that is removed
+    # by the webserver in front
     testapp.xget(
         200, URL("/%s/+simple/qpwoei/" % api.stagename).joinpath(links[0]).path,
+        headers=headers)
+
+
+def test_simple_project_absolute_url(mapp, pypistage, testapp):
+    api = mapp.create_and_use(indexconfig=dict(bases=["root/pypi"]))
+    mapp.upload_file_pypi(
+        "qpwoei-1.0.tar.gz", b'123', "qpwoei", "1.0", indexname=api.stagename)
+    pypistage.mock_simple("qpwoei", text='<a href="/qpwoei-1.0.zip"/>')
+    headers={str('X-devpi-absolute-urls'): str("")}
+    r = testapp.get("/%s/+simple/qpwoei/" % api.stagename, headers=headers)
+    assert r.status_code == 200
+    links = sorted(x["href"] for x in BeautifulSoup(r.text, "html.parser").findAll("a"))
+    assert len(links) == 2
+    hash_spec = get_default_hash_spec(b'123')
+    hashdir = "/".join(make_splitdir(hash_spec))
+    assert links == [
+        'http://localhost/root/pypi/+e/https_pypi.org/qpwoei-1.0.zip',
+        'http://localhost/user1/dev/+f/%s/qpwoei-1.0.tar.gz#%s' % (hashdir, hash_spec)]
+    testapp.xget(200, links[1], headers=headers)
+    headers.update({str('X-outside-url'): str("http://localhost/devpi")})
+    r = testapp.get("/%s/+simple/qpwoei/" % api.stagename, headers=headers)
+    assert r.status_code == 200
+    links = sorted(x["href"] for x in BeautifulSoup(r.text, "html.parser").findAll("a"))
+    assert len(links) == 2
+    hash_spec = get_default_hash_spec(b'123')
+    hashdir = "/".join(make_splitdir(hash_spec))
+    assert links == [
+        'http://localhost/devpi/root/pypi/+e/https_pypi.org/qpwoei-1.0.zip',
+        'http://localhost/devpi/user1/dev/+f/%s/qpwoei-1.0.tar.gz#%s' % (hashdir, hash_spec)]
+    # the internal url is always without the "devpi" part, as that is removed
+    # by the webserver in front
+    testapp.xget(
+        200, links[1].replace("http://localhost/devpi", "http://localhost"),
         headers=headers)
 
 


### PR DESCRIPTION
…when ``--absolute-urls`` option is used or ``X-DEVPI-ABSOLUTE-URLS`` header is set.