### PR TITLE
530 pkg cache headers

### DIFF
--- a/server/devpi_server/__init__.py
+++ b/server/devpi_server/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '4.5.1.dev0'
+__version__ = '4.6.0.dev0'

--- a/server/devpi_server/filestore.py
+++ b/server/devpi_server/filestore.py
@@ -220,6 +220,7 @@ class FileEntry(object):
         m = mimetypes.guess_type(self.basename)[0]
         headers[str("content-type")] = str(m)
         headers[str("content-length")] = str(self.file_size())
+        headers[str("cache-control")] = str("max-age=365000000, immutable, public")
         return headers
 
     def __eq__(self, other):

--- a/server/devpi_server/views.py
+++ b/server/devpi_server/views.py
@@ -979,16 +979,14 @@ class PyPIView:
             relpath = relpath.split("#", 1)[0]
         filestore = self.xom.filestore
         entry = filestore.get_file_entry(relpath)
+        if entry is None:
+            abort(request, 404, "no such file")
+        elif not entry.meta:
+            abort(request, 410, "file existed, deleted in later serial")
+
         if json_preferred(request):
-            if not entry or not entry.meta:
-                apireturn(404, "no such release file")
             entry_data = get_mutable_deepcopy(entry.meta)
             apireturn(200, type="releasefilemeta", result=entry_data)
-        if not entry or not entry.meta:
-            if entry is None:
-                abort(request, 404, "no such file")
-            else:
-                abort(request, 410, "file existed, deleted in later serial")
 
         try:
             if should_fetch_remote_file(entry, request.headers):

--- a/server/news/530.feature
+++ b/server/news/530.feature
@@ -1,0 +1,1 @@
+implement #530: set caching headers for release files to expire far in the future.

--- a/server/setup.py
+++ b/server/setup.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
       keywords="pypi realtime cache server",
       long_description="\n\n".join([README, CHANGELOG]),
       url="http://doc.devpi.net",
-      version='4.5.1.dev0',
+      version='4.6.0.dev0',
       maintainer="Holger Krekel, Florian Schulze",
       maintainer_email="holger@merlinux.eu",
       packages=find_packages(),


### PR DESCRIPTION
This is unfortunately a blind shot for now. I copied the headers from pypi.org. I tried to verify this with pip, but the CacheControl code is initialized and then never triggered. I think I saw lots of caching related info when using ``-vvv`` during install with older pip versions, but with 9.0.3 and 10.0.1 I don't see that anymore. I have no idea what changed.