### PR TITLE
Implement #557: export directory symlinks

### DIFF
--- a/client/devpi/upload.py
+++ b/client/devpi/upload.py
@@ -304,7 +304,7 @@ class Checkout:
         newrepo = basetemp.join(self.rootpath.basename)
         for fn in files:
             source = self.rootpath.join(fn)
-            if source.isfile():
+            if source.isfile() or source.islink():
                 dest = newrepo.join(fn)
                 dest.dirpath().ensure(dir=1)
                 source.copy(dest, mode=True)

--- a/client/news/557.bugfix
+++ b/client/news/557.bugfix
@@ -1,0 +1,1 @@
+fix #557: enable exporting links to directories


### PR DESCRIPTION
This fixes #557. `python setup.py sdist` packages symlinks too.