### PR TITLE
Fix copying of symlinks

### DIFF
--- a/client/devpi/upload.py
+++ b/client/devpi/upload.py
@@ -304,7 +304,11 @@ class Checkout:
         newrepo = basetemp.join(self.rootpath.basename)
         for fn in files:
             source = self.rootpath.join(fn)
-            if source.isfile() or source.islink():
+            if source.islink():
+                dest = newrepo.join(fn)
+                dest.dirpath().ensure(dir=1)
+                dest.mksymlinkto(source.readlink(), absolute=True)
+            elif source.isfile():
                 dest = newrepo.join(fn)
                 dest.dirpath().ensure(dir=1)
                 source.copy(dest, mode=True)

--- a/client/testing/test_upload.py
+++ b/client/testing/test_upload.py
@@ -60,7 +60,7 @@ class TestCheckout:
         setup_path = setupdir.ensure("setup.py")
         if not sys.platform.startswith("win"):
             setup_path.chmod(int("0777", 8))
-            link.mksymlinkto(py.path.local(".."), absolute=False)
+            link.mksymlinkto("..", absolute=True)
         else:
             link.write("no symlinks on windows")
 
@@ -100,6 +100,8 @@ class TestCheckout:
         result = checkout.export(newrepo)
         assert result.rootpath.join("file").check()
         assert result.rootpath.join("link").check()
+        if not sys.platform.startswith("win"):
+            assert result.rootpath.join("link").readlink() == ".."
         assert result.rootpath == newrepo.join(repo.basename).join(
             repo.bestrelpath(setupdir))
         # ensure we also copied repo meta info
@@ -121,7 +123,7 @@ class TestCheckout:
         assert p.exists()
         if not sys.platform.startswith("win"):
             assert p.stat().mode & int("0777", 8) == int("0777", 8)
-            assert result.rootpath.join("link").isdir()
+            assert result.rootpath.join("link").readlink() == '..'
         assert result.rootpath == newrepo.join(setupdir.basename)
 
     def test_vcs_export_disabled(self, uploadhub, setupdir,


### PR DESCRIPTION
In the last PR I made a mistake assuming that `source.copy` would copy the symlink as-is. Instead it copied the directory. This PR contains the fix for that and improved tests. I'll add the news file if necessary or we can reuse the previous one.

Copying the repository manually is quite tricky. What do you think about using git shallow clone from directory instead?