### PR TITLE
Add setting for max request body size (allow larger package upload)

### DIFF
--- a/server/devpi_server/config.py
+++ b/server/devpi_server/config.py
@@ -45,6 +45,10 @@ def addoptions(parser, pluginmanager):
             default=50,
             help="number of threads to start for serving clients.")
 
+    web.addoption("--max-request-body-size",  type=int,
+            default=1073741824,
+            help="maximum number of bytes in request body.")
+
     web.addoption("--outside-url",  type=str, dest="outside_url",
             metavar="URL",
             default=None,

--- a/server/devpi_server/config.py
+++ b/server/devpi_server/config.py
@@ -47,7 +47,8 @@ def addoptions(parser, pluginmanager):
 
     web.addoption("--max-request-body-size",  type=int,
             default=1073741824,
-            help="maximum number of bytes in request body.")
+            help="maximum number of bytes in request body. "
+                 "This controls the max size of package that can be uploaded.")
 
     web.addoption("--outside-url",  type=str, dest="outside_url",
             metavar="URL",

--- a/server/devpi_server/main.py
+++ b/server/devpi_server/main.py
@@ -136,6 +136,7 @@ def wsgi_run(xom, app):
     host = xom.config.args.host
     port = xom.config.args.port
     threads = xom.config.args.threads
+    max_body = xom.config.args.max_request_body_size
     log = xom.log
     log.info("devpi-server version: %s", server_version)
     log.info("serverdir: %s" % xom.config.serverdir)
@@ -151,7 +152,7 @@ def wsgi_run(xom, app):
         app = make_eval_exception(app, {})
     try:
         log.info("Hit Ctrl-C to quit.")
-        serve(app, host=host, port=port, threads=threads)
+        serve(app, host=host, port=port, threads=threads, max_request_body_size=max_body)
     except KeyboardInterrupt:
         pass
     return 0

--- a/server/news/request_body_size.feature
+++ b/server/news/request_body_size.feature
@@ -1,0 +1,1 @@
+add `--max-request-body-size` option to control maximum upload size

--- a/server/test_devpi_server/test_main.py
+++ b/server/test_devpi_server/test_main.py
@@ -249,8 +249,16 @@ def test_init_server_directory(call_devpi_in_dir, tmpdir):
 
 
 def test_serve_threads(monkeypatch, tmpdir):
-    def check_threads(app, host, port, threads):
+    def check_threads(app, host, port, threads, max_request_body_size):
         assert threads == 100
     monkeypatch.setattr("waitress.serve", check_threads)
     from devpi_server.main import main
     main(["devpi-server", "--threads", "100"])
+
+
+def test_serve_max_body(monkeypatch, tmpdir):
+    def check_max_body(app, host, port, threads, max_request_body_size):
+        assert max_request_body_size == 42
+    monkeypatch.setattr("waitress.serve", check_max_body)
+    from devpi_server.main import main
+    main(["devpi-server", "--max-request-body-size", "42"])


### PR DESCRIPTION
Some people have a use-case of uploading very large (> 1GB) packages, see for example https://github.com/devpi/devpi/issues/342#issuecomment-290658626.

This patch adds an option to set max_request_body_size passed to waitress, allowing those users to set a higher maximum request size.

I note that in the linked issue there are comments suggesting that devpi loads the entire file contents into memory, so you may want to expand the help text to warn users. (I didn't observe any issues uploading a 2.5GB file, but with larger sizes or low-spec clients/servers there may be problems - I don't know.)

I have not created any test cases for this change as I'm unsure what tests would be of use -- I have manually tested that running with the option set to a low value causes a 413 error on upload; however this seems like something that would already be covered by waitress' tests...