### PR TITLE
Remove scraping/crawling

### DIFF
--- a/server/devpi_server/filestore.py
+++ b/server/devpi_server/filestore.py
@@ -70,7 +70,6 @@ class FileStore:
                 basename=basename)
         entry = FileEntry(self.xom, key, readonly=False)
         entry.url = link.geturl_nofragment().url
-        entry.eggfragment = link.eggfragment
         # verify checksum if the entry is fresh, a file exists
         # and the link specifies a checksum.  It's a situation
         # that shouldn't happen unless some manual file system
@@ -84,13 +83,10 @@ class FileStore:
         entry.hash_spec = unicode_if_bytes(link.hash_spec)
         entry.project = project
         version = None
-        if link.eggfragment:
-            version = link.eggfragment[len(project) + 1:]
-        else:
-            try:
-                (projectname, version, ext) = splitbasename(basename)
-            except ValueError:
-                pass
+        try:
+            (projectname, version, ext) = splitbasename(basename)
+        except ValueError:
+            pass
         # only store version on entry if we can determine it
         # since version is a meta property of FileEntry, it will return None
         # if not set, if we set it explicitly, it would waste space in the
@@ -148,6 +144,9 @@ class BadGateway(Exception):
 class FileEntry(object):
     BadGateway = BadGateway
     hash_spec = metaprop("hash_spec")  # e.g. "md5=120938012"
+    # BBB keep this until devpi-server 6.0.0,
+    # it was required for devpi-web <= 3.5.1
+    # it was used for the old scraping/crawling code
     eggfragment = metaprop("eggfragment")
     last_modified = metaprop("last_modified")
     url = metaprop("url")
@@ -310,7 +309,7 @@ class FileEntry(object):
             err = ValueError(
                       "%s: got %s bytes of %r from remote, expected %s" % (
                       self.relpath, filesize, r.url, content_size))
-        if not err and not self.eggfragment:
+        if not err:
             err = self.check_checksum(content)
 
         if err is not None:

--- a/server/devpi_server/model.py
+++ b/server/devpi_server/model.py
@@ -451,7 +451,7 @@ class BaseStage(object):
     def _make_elink(self, project, key, href, require_python):
         rp = SimplelinkMeta((key, href, require_python))
         linkdict = {"entrypath": rp._url.path, "hash_spec": rp._url.hash_spec,
-                "eggfragment": rp.eggfragment, "require_python": require_python}
+                    "require_python": require_python}
         return ELink(self.filestore, linkdict, project, rp.version)
 
     def get_linkstore_perstage(self, name, version, readonly=True):
@@ -897,7 +897,7 @@ class ELink(object):
         try:
             return self.linkdict[name]
         except KeyError:
-            if name in ("for_entrypath", "eggfragment", "rel"):
+            if name in ("for_entrypath", "rel"):
                 return None
             raise AttributeError(name)
 
@@ -1042,20 +1042,10 @@ class SimplelinkMeta(CompareMixin):
         self.key, self.href, self.require_python = key_href
         self._url = URL(self.href)
         self.name, self.version, self.ext = splitbasename(self._url.basename, checkarch=False)
-        self.eggfragment = self._url.eggfragment
 
     @cached_property
     def cmpval(self):
         return parse_version(self.version), normalize_name(self.name), self.ext
-
-    def get_eggfragment_or_version(self):
-        """ return the egg-identifier (link ending in #egg=ID)
-        or the version of the basename
-        """
-        if self.eggfragment:
-            return "egg=" + self.eggfragment
-        else:
-            return self.version
 
 
 def make_key_and_href(entry):
@@ -1064,9 +1054,6 @@ def make_key_and_href(entry):
     href = entry.relpath
     if entry.hash_spec:
         href += "#" + entry.hash_spec
-    elif entry.eggfragment:
-        href += "#egg=%s" % entry.eggfragment
-        return entry.eggfragment, href
     return entry.basename, href
 
 

--- a/server/devpi_server/views.py
+++ b/server/devpi_server/views.py
@@ -1224,12 +1224,7 @@ class PyPIView:
 
 
 def should_fetch_remote_file(entry, headers):
-    from .replica import H_REPLICA_FILEREPL
     should_fetch = not entry.file_exists()
-    # if we are asked for an "egg" development link we cause
-    # refetching it unless we are called within file replication context
-    if entry.eggfragment and not headers.get(H_REPLICA_FILEREPL):
-        should_fetch = True
     return should_fetch
 
 

--- a/server/news/518.removal
+++ b/server/news/518.removal
@@ -1,0 +1,1 @@
+fix #518: There are no URLs on PyPI anymore that need to be scraped or crawled, so the code for that was removed.

--- a/server/test_devpi_server/test_extpypi.py
+++ b/server/test_devpi_server/test_extpypi.py
@@ -4,7 +4,7 @@ import time
 import hashlib
 import pytest
 
-from devpi_server.extpypi import URL, parse_index, threadlog
+from devpi_server.extpypi import URL, parse_index
 from devpi_server.extpypi import ProjectNamesCache, ProjectUpdateCache
 from test_devpi_server.conftest import getmd5
 
@@ -47,39 +47,8 @@ class TestIndexParsing:
         result = parse_index(simplepy,
             """<a href="../../pkg/py-1.4.12.zip#md5=12ab">qwe</a>
                <a href="../../pkg/PY-1.4.13.zip">qwe</a>
-               <a href="../../pkg/pyzip#egg=py-dev">qwe</a>
         """)
-        assert len(result.releaselinks) == 3
-
-    def test_parse_index_simple_dir_egg_issue63(self):
-        simplepy = URL("https://pypi.org/simple/py/")
-        result = parse_index(simplepy,
-            """<a href="../../pkg/py-1.4.12.zip#md5=12ab">qwe</a>
-               <a href="../../pkg/#egg=py-dev">qwe</a>
-        """)
-        assert len(result.releaselinks) == 1
-
-    def test_parse_index_egg_svnurl(self, monkeypatch):
-        # strange case reported by fschulze/witsch where
-        # urlparsing will yield a fragment for svn urls.
-        # it's not exactly clear how urlparse.uses_fragment
-        # sometimes contains "svn" but it's good to check
-        # that we are not sensitive to the issue.
-        try:
-            import urllib.parse as urlparse
-        except ImportError:
-            # PY2
-            import urlparse
-        monkeypatch.setattr(urlparse, "uses_fragment",
-                            urlparse.uses_fragment + ["svn"])
-        simplepy = URL("https://pypi.org/simple/zope.sqlalchemy/")
-        result = parse_index(simplepy,
-            '<a href="svn://svn.zope.org/repos/main/'
-            'zope.sqlalchemy/trunk#egg=zope.sqlalchemy-dev" />'
-        )
-        assert len(result.releaselinks) == 0
-        assert len(result.egglinks) == 0
-        #assert 0, (result.releaselinks, result.egglinks)
+        assert len(result.releaselinks) == 2
 
     def test_parse_index_normalized_name(self):
         simplepy = URL("https://pypi.org/simple/ndg-httpsclient/")
@@ -88,14 +57,6 @@ class TestIndexParsing:
         """)
         assert len(result.releaselinks) == 1
         assert result.releaselinks[0].url.endswith("ndg_httpsclient-1.0.tar.gz")
-
-    def test_parse_index_two_eggs_same_url(self):
-        simplepy = URL("https://pypi.org/simple/Py/")
-        result = parse_index(simplepy,
-            """<a href="../../pkg/pyzip#egg=py-dev">qwe2</a>
-               <a href="../../pkg/pyzip#egg=py-dev">qwe</a>
-        """)
-        assert len(result.releaselinks) == 1
 
     def test_parse_index_simple_nomatch(self):
         result = parse_index(self.simplepy,
@@ -113,28 +74,12 @@ class TestIndexParsing:
         assert len(result.releaselinks) == 1
         link, = result.releaselinks
         assert link == "http://pylib2.org/py-1.0.zip"
-        assert len(result.crawllinks) == 2
-        assert result.crawllinks == \
-                    set(["http://pylib.org", "http://pylib2.org"])
 
     def test_parse_index_invalid_link(self, pypistage):
         result = parse_index(self.simplepy, '''
                 <a rel="download" href="https:/host.com/123" />
         ''')
-        assert result.crawllinks == {
-            URL('https://pypi.org/host.com/123')}
-
-    def test_parse_index_with_egg(self):
-        result = parse_index(self.simplepy,
-            """<a href="http://bb.org/download/py.zip#egg=py-dev" />
-               <a href="http://bb.org/download/py-1.0.zip" />
-               <a href="http://bb.org/download/py.zip#egg=something-dev" />
-        """)
-        assert len(result.releaselinks) == 2
-        link, link2 = result.releaselinks
-        assert link.basename == "py.zip"
-        assert link.eggfragment == "py-dev"
-        assert link2.basename == "py-1.0.zip"
+        assert result.releaselinks == []
 
     def test_parse_index_with_wheel(self):
         result = parse_index(self.simplepy,
@@ -214,22 +159,6 @@ class TestIndexParsing:
         link, = result.releaselinks
         assert link.basename == "py-1.0.zip"
 
-    def test_parse_index_with_two_eggs_ordering(self):
-        # it seems that pip/easy_install in some cases
-        # rely on the exact ordering of eggs in the html page
-        # for example with nose, there are two eggs and the second/last
-        # one is chosen due to the internal pip/easy_install algorithm
-        result = parse_index(self.simplepy,
-            """<a href="http://bb.org/download/py.zip#egg=py-dev" />
-               <a href="http://other/master#egg=py-dev" />
-        """)
-        assert len(result.releaselinks) == 2
-        link1, link2 = result.releaselinks
-        assert link1.basename == "master"
-        assert link1.eggfragment == "py-dev"
-        assert link2.basename == "py.zip"
-        assert link2.eggfragment == "py-dev"
-
     def test_parse_index_with_matchingproject_no_version(self):
         result = parse_index(self.simplepy,
             """<a href="http://bb.org/download/p.zip" />
@@ -249,12 +178,10 @@ class TestIndexParsing:
                <a href="http://pylib2.org" rel="download">whatever2</a>
         """)
         assert len(result.releaselinks) == 1
-        assert len(result.crawllinks) == 2
         result.parse_index(URL("http://pylib.org"), """
                <a href="http://pylib.org/py-1.1-py27.egg" />
                <a href="http://pylib.org/other" rel="download" />
-        """, scrape=False)
-        assert len(result.crawllinks) == 2
+        """)
         assert len(result.releaselinks) == 2
         links = list(result.releaselinks)
         assert links[0].url == "https://pypi.org/pkg/py-1.4.12.zip#md5=12ab"
@@ -265,7 +192,6 @@ class TestIndexParsing:
             """<a href="ftp://pylib2.org/py-1.0.tar.gz"
                   rel="download">whatever2</a> """)
         assert len(result.releaselinks) == 0
-        assert len(result.crawllinks) == 0
 
 
     def test_releasefile_md5_matching_and_ordering(self):
@@ -280,13 +206,11 @@ class TestIndexParsing:
                <a href="http://pylib2.org" rel="download">whatever2</a>
         """)
         assert len(result.releaselinks) == 3
-        assert len(result.crawllinks) == 2
         result.parse_index(URL("http://pylib.org"), """
                <a href="http://pylib.org/py-1.4.12.zip" />
                <a href="http://pylib.org/py-1.4.11.zip#md5=1111" />
                <a href="http://pylib.org/py-1.4.10.zip#md5=12ab" />
-        """, scrape=False)
-        assert len(result.crawllinks) == 2
+        """)
         assert len(result.releaselinks) == 3
         link1, link2, link3 = result.releaselinks
         assert link1.url == "https://pypi.org/pkg/py-1.4.12.zip#md5=12ab"
@@ -308,19 +232,6 @@ class TestExtPYPIDB:
         assert not link.hash_spec
         assert link.entrypath.endswith("/pytest-1.0.zip")
         assert link.entrypath == link.entry.relpath
-
-    def test_parse_project_replaced_eggfragment(self, pypistage):
-        pypistage.mock_simple("pytest", pypiserial=10,
-            pkgver="pytest-1.0.zip#egg=pytest-dev1")
-        links = pypistage.get_releaselinks("pytest")
-        assert links[0].eggfragment == "pytest-dev1"
-
-        pypistage.cache_retrieve_times.expire("pytest")
-        pypistage.mock_simple("pytest", pypiserial=11,
-            pkgver="pytest-1.0.zip#egg=pytest-dev2")
-        threadlog.info("hello")
-        links = pypistage.get_releaselinks("pytest")
-        assert links[0].eggfragment == "pytest-dev2"
 
     @pytest.mark.parametrize("hash_type", ["md5", "sha256"])
     def test_parse_project_replaced_md5(self, pypistage, hash_type):
@@ -348,26 +259,18 @@ class TestExtPYPIDB:
         assert data["version"] == "1.0"
         assert pypistage.has_project_perstage("pytest")
 
-    def test_get_versiondata_with_egg(self, pypistage):
-        pypistage.mock_simple("pytest", text='''
-            <a href="../../pkg/tip.zip#egg=pytest-dev" />''')
-        data = pypistage.get_versiondata("Pytest", "egg=pytest-dev")
-        assert data["+elinks"]
-
-    def test_parse_and_scrape(self, pypistage):
+    def test_parse_with_external_link(self, pypistage):
         md5 = getmd5("123")
         pypistage.mock_simple("pytest", text='''
                 <a href="../../pkg/pytest-1.0.zip#md5={md5}" />
                 <a rel="download" href="https://download.com/index.html" />
             '''.format(md5=md5), pypiserial=20)
-        pypistage.url2response["https://download.com/index.html"] = dict(
-            status_code=200, text = '''
-                <a href="pytest-1.1.tar.gz" /> ''',
-            headers = {"content-type": "text/html"})
         links = pypistage.get_releaselinks("pytest")
-        assert len(links) == 2
-        assert links[0].entry.url == "https://download.com/pytest-1.1.tar.gz"
-        assert links[0].entrypath.endswith("/pytest-1.1.tar.gz")
+        # the rel="download" link is just ignored,
+        # originally it was scraped/crawled
+        assert len(links) == 1
+        assert links[0].entry.url == "https://pypi.org/pkg/pytest-1.0.zip"
+        assert links[0].entrypath.endswith("/pytest-1.0.zip")
 
         links = pypistage.get_linkstore_perstage("pytest", "1.0").get_links()
         assert len(links) == 1
@@ -383,9 +286,11 @@ class TestExtPYPIDB:
                 <a rel="download" href="https://download.com/index.html" />
             '''.format(md5=md5, hashdir_b=hashdir_b), pypiserial=25)
         links = pypistage.get_releaselinks("pytest")
-        assert len(links) == 3
-        assert links[1].entry.url == "https://pypi.org/pkg/pytest-1.0.1.zip"
-        assert links[1].entrypath.endswith("/pytest-1.0.1.zip")
+        assert len(links) == 2
+        assert links[0].entry.url == "https://pypi.org/pkg/pytest-1.0.1.zip"
+        assert links[0].entrypath.endswith("/pytest-1.0.1.zip")
+        assert links[1].entry.url == "https://pypi.org/pkg/pytest-1.0.zip"
+        assert links[1].entrypath.endswith("/pytest-1.0.zip")
 
     def test_parse_and_scrape_non_html_ignored(self, pypistage):
         pypistage.mock_simple("pytest", text='''
@@ -444,24 +349,6 @@ class TestExtPYPIDB:
         assert len(links) == 1
         assert links[0].entry.url == \
                 "https://pypi.org/pkg/pytest-1.0.zip"
-
-    def test_scrape_not_recursive(self, pypistage):
-        pypistage.mock_simple("pytest", text='''
-                <a rel="download" href="https://download.com/index.html" />
-            ''')
-        md5=getmd5("hello")
-        pypistage.url2response["https://download.com/index.html"] = dict(
-            status_code=200, text = '''
-                <a href="../../pkg/pytest-1.0.zip#md5={md5}" />
-                <a rel="download" href="http://whatever.com" />'''.format(
-                md5=md5),
-            headers = {"content-type": "text/html"},
-        )
-        pypistage.url2response["https://whatever.com"] = dict(
-            status_code=200, text = '<a href="pytest-1.1.zip#md5={md5}" />'
-                             .format(md5=md5))
-        links = pypistage.get_releaselinks("pytest")
-        assert len(links) == 1
 
     def test_parse_with_outdated_links_issue165(self, pypistage, caplog):
         pypistage.mock_simple("pytest", pypiserial=10, pkgver="pytest-1.0.zip")

--- a/server/test_devpi_server/test_model.py
+++ b/server/test_devpi_server/test_model.py
@@ -297,20 +297,6 @@ class TestStage:
         assert len(links) == 1
         assert links[0].entrypath.endswith("someproject-1.0.zip")
 
-    def test_get_releaselinks_inheritance_shadow_egg(self, pypistage, stage):
-        stage.modify(bases=("root/pypi",), mirror_whitelist=['py'])
-        pypistage.mock_simple("py",
-        """<a href="http://bb.org/download/py.zip#egg=py-dev" />
-           <a href="http://bb.org/download/master#egg=py-dev2" />
-        """)
-        register_and_store(stage, "py-1.0.tar.gz", b"123")
-        links = stage.get_releaselinks("py")
-        assert len(links) == 3
-        e0, e1, e2 = links
-        assert e0.basename == "py-1.0.tar.gz"
-        assert e1.basename == "py.zip"
-        assert e2.basename == "master"
-
     def test_inheritance_error_are_nop(self, pypistage, stage):
         stage.modify(bases=("root/pypi",), mirror_whitelist=['someproject'])
         pypistage.mock_simple("someproject", status_code = -1)

--- a/server/test_devpi_server/test_replica.py
+++ b/server/test_devpi_server/test_replica.py
@@ -716,18 +716,6 @@ class TestFileReplication:
         assert list(replication_errors.errors.keys()) == []
 
 
-def test_should_fetch_remote_file():
-    from devpi_server.views import should_fetch_remote_file
-    from devpi_server.replica import H_REPLICA_FILEREPL
-    class Entry:
-        eggfragment = "some"
-        def file_exists(self):
-            return True
-    assert should_fetch_remote_file(Entry(), {})
-    assert not \
-           should_fetch_remote_file(Entry(), {H_REPLICA_FILEREPL: str("YES")})
-
-
 def test_simplelinks_update_updates_projectname(httpget, monkeypatch,
     pypistage, replica_pypistage, pypiurls, replica_xom, xom):
 

--- a/server/test_devpi_server/test_views.py
+++ b/server/test_devpi_server/test_views.py
@@ -123,7 +123,7 @@ def test_simple_project(pypistage, testapp):
     assert r.headers["X-DEVPI-SERIAL"]
     # easy_install fails if the result isn't html
     assert "html" in r.headers['content-type']
-    assert not parse_index("http://localhost", r.text, scrape=False).releaselinks
+    assert not parse_index("http://localhost", r.text).releaselinks
 
     path = "/%s-1.0.zip" % name
     pypistage.mock_simple(name, text='<a href="%s"/>' % path)

--- a/web/devpi_web/views.py
+++ b/web/devpi_web/views.py
@@ -239,7 +239,11 @@ def get_files_info(request, linkstore, show_toxresults=False):
     for link in sorted(filedata, key=attrgetter('basename')):
         url = url_for_entrypath(request, link.entrypath)
         entry = link.entry
-        if entry.eggfragment:
+        if getattr(entry, 'eggfragment', None):
+            # BBB for older devpi-server (<5.0.0)
+            # before 5.0.0, eggfragment value was the result of searching for
+            # downloads outside PyPI via scraping
+            # can be removed once devpi-web requires devpi-server >= 5.0.0
             url += "#egg=%s" % entry.eggfragment
         elif entry.hash_spec:
             url += "#" + entry.hash_spec


### PR DESCRIPTION
Fix #518: There are no URLs on PyPI anymore that need to be scraped or crawled, so the code for that was removed.