### PR TITLE
Allow deletion of specific package versions on a mirror.

### DIFF
--- a/postgresql/devpi_postgresql/main.py
+++ b/postgresql/devpi_postgresql/main.py
@@ -92,6 +92,7 @@ class Connection:
         q = "SELECT set_files(%s, %s, %s)"
         c.execute(q, (path, len(content), pg8000.Binary(content)))
         c.close()
+        self.dirty_files[path] = content
 
     def io_file_open(self, path):
         return py.io.BytesIO(self.io_file_get(path))
@@ -123,6 +124,7 @@ class Connection:
         q = "DELETE FROM files WHERE path = %s"
         c.execute(q, (path,))
         c.close()
+        self.dirty_files[path] = None
 
     def get_raw_changelog_entry(self, serial):
         q = "SELECT data FROM changelog WHERE serial = %s"

--- a/server/devpi_server/keyfs_sqlite.py
+++ b/server/devpi_server/keyfs_sqlite.py
@@ -97,6 +97,7 @@ class Connection(BaseConnection):
         q = "INSERT OR REPLACE INTO files (path, size, data) VALUES (?, ?, ?)"
         c.execute(q, (path, len(content), sqlite3.Binary(content)))
         c.close()
+        self.dirty_files[path] = content
 
     def io_file_open(self, path):
         return py.io.BytesIO(self.io_file_get(path))
@@ -128,6 +129,7 @@ class Connection(BaseConnection):
         q = "DELETE FROM files WHERE path = ?"
         c.execute(q, (path,))
         c.close()
+        self.dirty_files[path] = None
 
     def write_transaction(self):
         return Writer(self.storage, self)

--- a/server/devpi_server/views.py
+++ b/server/devpi_server/views.py
@@ -984,8 +984,6 @@ class PyPIView:
     def del_versiondata(self):
         stage = self.context.stage
         name, version = self.context.project, self.context.version
-        if stage.ixconfig["type"] == "mirror":
-            abort(self.request, 405, "cannot delete on mirror index")
         if not stage.ixconfig["volatile"]:
             abort(self.request, 403, "cannot delete version on non-volatile index")
         try:

--- a/server/news/del_mirror_version.feature
+++ b/server/news/del_mirror_version.feature
@@ -1,0 +1,1 @@
+Allow deletion of specific package versions on a mirror. Only the downloaded files will be removed. The file will be fetched again from the mirror source on request.

--- a/server/test_devpi_server/conftest.py
+++ b/server/test_devpi_server/conftest.py
@@ -396,7 +396,7 @@ def add_pypistage_mocks(monkeypatch, httpget):
                    "content-type": mimetypes.guess_type(path),
                    "last-modified": "today",}
         url = URL(self.mirror_url).joinpath(path)
-        return self.httpget.mockresponse(url.url, raw=py.io.BytesIO(content),
+        return self.httpget.mockresponse(url.url, content=content,
                                          headers=headers, **kw)
     monkeypatch.setattr(PyPIStage, "mock_extfile", mock_extfile, raising=False)
 

--- a/server/test_devpi_server/test_views.py
+++ b/server/test_devpi_server/test_views.py
@@ -1661,12 +1661,10 @@ def test_delete_from_mirror(mapp, pypistage, testapp):
         assert get_pypi_project_names(testapp) == set([name])
         assert not getentry(testapp, path).file_exists()
     assert '/+e/' in link
-    mapp.delete_project("pytest/2.6", code=405)
     mapp.delete_project("pytest", code=403)
     # make non volatile
     res = mapp.getjson("/root/pypi")["result"]
     mapp.modify_index("root/pypi", indexconfig=dict(res, volatile=True))
-    mapp.delete_project("pytest/2.6", code=405)
     mapp.delete_project("pytest", code=200)
     r = testapp.get(link)
     with testapp.xom.keyfs.transaction():
@@ -1679,7 +1677,6 @@ def test_delete_from_mirror(mapp, pypistage, testapp):
         for x in getlinks(r.text))
     assert '2.5' in other_link
     assert '2.6' in link
-    mapp.delete_project("pytest/2.6", code=405)
     mapp.delete_project("pytest", code=200)
     with testapp.xom.keyfs.transaction():
         assert get_pypi_project_names(testapp) == set()
@@ -1687,6 +1684,71 @@ def test_delete_from_mirror(mapp, pypistage, testapp):
         key = testapp.xom.filestore.get_key_from_relpath(path.strip("/"))
         assert not key.exists()
         assert not getentry(testapp, other_path).file_exists()
+
+
+def test_delete_version_from_mirror(mapp, pypistage, testapp):
+    mapp.login_root()
+    mapp.use("root/pypi")
+    name = "pytest"
+    mirrorpath25 = "/%s-2.5.zip" % name
+    mirrorpath26 = "/%s-2.6.zip" % name
+    pypistage.mock_simple(name, text='<a href="%s"/>\n<a href="%s"/>' % (mirrorpath25, mirrorpath26))
+    pypistage.mock_extfile(mirrorpath25, b"123")
+    pypistage.mock_extfile(mirrorpath26, b"456")
+    # now we have pytest-2.5 and pytest-2.6 releases mocked
+    # get the links to extract the paths
+    r = testapp.get('/root/pypi/+simple/%s' % name)
+    (link25, link26) = sorted(
+        x.get('href').replace('../../', '/root/pypi/')
+        for x in getlinks(r.text))
+    path25 = link25[1:]
+    path26 = link26[1:]
+    assert '2.5' in path25
+    assert '2.6' in path26
+    # download pytest-2.5
+    r = testapp.get(link25)
+    with testapp.xom.keyfs.transaction():
+        assert not getentry(testapp, path26).file_exists()
+        assert getentry(testapp, path25).file_exists()
+    assert '/+e/' in link26
+    # test that the delete fails, since the index is not volatile by default
+    mapp.delete_project("pytest/2.6", code=403)
+    # make volatile
+    res = mapp.getjson("/root/pypi")["result"]
+    mapp.modify_index("root/pypi", indexconfig=dict(res, volatile=True))
+    # check that deleting the not yet downloaded 2.6 doesn't cause an error
+    # and also doesn't change anything in the db
+    mapp.delete_project("pytest/2.6", code=200)
+    with testapp.xom.keyfs.transaction():
+        assert not getentry(testapp, path26).file_exists()
+        assert getentry(testapp, path25).file_exists()
+    # now download pytest-2.6
+    r = testapp.get(link26)
+    with testapp.xom.keyfs.transaction():
+        assert getentry(testapp, path26).file_exists()
+        assert getentry(testapp, path25).file_exists()
+    # update links after download by explicitly expiring the cache
+    pypistage.cache_retrieve_times.expire("pytest")
+    r = testapp.get('/root/pypi/+simple/%s' % name)
+    (link25, link26) = sorted(
+        x.get('href').replace('../../', '/root/pypi/')
+        for x in getlinks(r.text))
+    assert '2.5' in link25
+    assert '2.6' in link26
+    # delete again, now pytest-2.6 should be removed, but pytest-2.5
+    # should still be there
+    mapp.delete_project("pytest/2.6", code=200)
+    with testapp.xom.keyfs.transaction():
+        assert not getentry(testapp, path26).file_exists()
+        # only the file is deleted, the key for it still exists
+        key = testapp.xom.filestore.get_key_from_relpath(path26.strip("/"))
+        assert key.exists()
+        assert getentry(testapp, path25).file_exists()
+    # make sure download still works after deletion
+    r = testapp.xget(200, link26)
+    with testapp.xom.keyfs.transaction():
+        assert getentry(testapp, path26).file_exists()
+        assert getentry(testapp, path25).file_exists()
 
 
 def test_delete_volatile_fails(mapp):

--- a/server/test_devpi_server/test_views.py
+++ b/server/test_devpi_server/test_views.py
@@ -41,6 +41,10 @@ def getentry(testapp, path):
     return testapp.xom.filestore.get_file_entry(path.strip("/"))
 
 
+def get_pypi_project_names(testapp):
+    return testapp.xom.model.getstage('root/pypi').key_projects.get()
+
+
 def hash_spec_matches(hash_spec, content):
     hash_type, hash_value = hash_spec.split("=")
     digest = getattr(hashlib, hash_type)(content).hexdigest()
@@ -1654,8 +1658,7 @@ def test_delete_from_mirror(mapp, pypistage, testapp):
     assert '2.5' in other_path
     assert '2.6' in path
     with testapp.xom.keyfs.transaction():
-        stage = testapp.xom.model.getstage('root/pypi')
-        assert stage.key_projects.get() == set([name])
+        assert get_pypi_project_names(testapp) == set([name])
         assert not getentry(testapp, path).file_exists()
     assert '/+e/' in link
     mapp.delete_project("pytest/2.6", code=405)
@@ -1667,8 +1670,7 @@ def test_delete_from_mirror(mapp, pypistage, testapp):
     mapp.delete_project("pytest", code=200)
     r = testapp.get(link)
     with testapp.xom.keyfs.transaction():
-        stage = testapp.xom.model.getstage('root/pypi')
-        assert stage.key_projects.get() == set([name])
+        assert get_pypi_project_names(testapp) == set([name])
         assert getentry(testapp, path).file_exists()
         assert not getentry(testapp, other_path).file_exists()
     r = testapp.get('/root/pypi/+simple/%s' % name)
@@ -1680,8 +1682,7 @@ def test_delete_from_mirror(mapp, pypistage, testapp):
     mapp.delete_project("pytest/2.6", code=405)
     mapp.delete_project("pytest", code=200)
     with testapp.xom.keyfs.transaction():
-        stage = testapp.xom.model.getstage('root/pypi')
-        assert stage.key_projects.get() == set()
+        assert get_pypi_project_names(testapp) == set()
         assert not getentry(testapp, path).file_exists()
         key = testapp.xom.filestore.get_key_from_relpath(path.strip("/"))
         assert not key.exists()
@@ -1830,8 +1831,7 @@ def test_delete_package_from_mirror(mapp, pypistage, testapp):
     path1 = link1[1:]
     path2 = link2[1:]
     with testapp.xom.keyfs.transaction():
-        stage = testapp.xom.model.getstage('root/pypi')
-        assert stage.key_projects.get() == set([name, other_name])
+        assert get_pypi_project_names(testapp) == set([name, other_name])
         assert not getentry(testapp, path1).file_exists()
         assert not getentry(testapp, path2).file_exists()
         assert getentry(testapp, other_path).file_exists()
@@ -1844,8 +1844,7 @@ def test_delete_package_from_mirror(mapp, pypistage, testapp):
     testapp.get(link1)
     testapp.get(link2)
     with testapp.xom.keyfs.transaction():
-        stage = testapp.xom.model.getstage('root/pypi')
-        assert stage.key_projects.get() == set([name, other_name])
+        assert get_pypi_project_names(testapp) == set([name, other_name])
         assert getentry(testapp, path1).file_exists()
         assert getentry(testapp, path2).file_exists()
         assert getentry(testapp, other_path).file_exists()
@@ -1857,15 +1856,13 @@ def test_delete_package_from_mirror(mapp, pypistage, testapp):
     path2 = link2[1:]
     testapp.xdel(200, link1)
     with testapp.xom.keyfs.transaction():
-        stage = testapp.xom.model.getstage('root/pypi')
-        assert stage.key_projects.get() == set([name, other_name])
+        assert get_pypi_project_names(testapp) == set([name, other_name])
         assert not getentry(testapp, path1).file_exists()
         assert getentry(testapp, path2).file_exists()
         assert getentry(testapp, other_path).file_exists()
     testapp.xdel(200, link2)
     with testapp.xom.keyfs.transaction():
-        stage = testapp.xom.model.getstage('root/pypi')
-        assert stage.key_projects.get() == set([other_name])
+        assert get_pypi_project_names(testapp) == set([other_name])
         assert not getentry(testapp, path1).file_exists()
         assert not getentry(testapp, path2).file_exists()
         assert getentry(testapp, other_path).file_exists()


### PR DESCRIPTION
Only the downloaded files will be removed.
The file will be fetched again from the mirror source on request.