### PR TITLE
Fix uploading documentation in devpi-client < 4.1.0.

### DIFF
--- a/common/devpi_common/proc.py
+++ b/common/devpi_common/proc.py
@@ -1,4 +1,19 @@
-from subprocess import CalledProcessError, PIPE, Popen
-from subprocess import check_output
+import sys
+from subprocess import Popen, CalledProcessError, PIPE
 
-__all__ = [CalledProcessError, PIPE, Popen, check_output]
+def check_output(*args, **kwargs):
+    # subprocess.check_output does not exist on python26
+    if "universal_newlines" not in kwargs:
+        kwargs["universal_newlines"] = True
+    popen = Popen(stdout=PIPE, *args, **kwargs)
+    output, unused_err = popen.communicate()
+    retcode = popen.poll()
+    if retcode:
+        cmd = kwargs.get("args")
+        if cmd is None:
+            cmd = args[0]
+        if sys.version_info < (2,7):
+            raise CalledProcessError(retcode, cmd)
+        else:
+            raise CalledProcessError(retcode, cmd, output=output)
+    return output

--- a/common/news/check_output.bugfix
+++ b/common/news/check_output.bugfix
@@ -1,0 +1,1 @@
+Fix uploading documentation in devpi-client < 4.1.0.


### PR DESCRIPTION
The backward compatibility version of check_output that was removed in devpi-common 3.3.0 behaved differently from the stock check_output function. Older versions of devpi-client 4.1.0 broke because of that.