### PR TITLE
Suggest Python 3.4 or above

### DIFF
--- a/doc/adminman/server.rst
+++ b/doc/adminman/server.rst
@@ -88,9 +88,9 @@ sqlite performance
 Sqlite can be used with a single writer and multiple readers without blocking.
 Unfortunately that behaviour isn't available in all setups.
 
-With Python 3.4 it is possible to explicitly request that behaviour when
-opening the database. So it is recommended that you run devpi-server
-using Python 3.4.
+Starting with Python 3.4 it is possible to explicitly request that behaviour 
+when opening the database. So it is recommended that you run devpi-server
+using Python 3.4 or above.
 
 Some setups compile sqlite in a way which allows to implicitly use the non
 blocking behaviour. It seems like OS X and FreeBSD have that by default. Most


### PR DESCRIPTION
Small correction on the suggested Python version to use based on when the `uri` parameter was added to `sqlite3.connect` method.