### PR TITLE
Use server side operations for modifying indexes

### DIFF
--- a/client/devpi/index.py
+++ b/client/devpi/index.py
@@ -76,12 +76,6 @@ def main(hub, args):
 
 def parse_keyvalue_spec_index(hub, keyvalues):
     try:
-        kvdict = parse_keyvalue_spec(keyvalues)
+        return parse_keyvalue_spec(keyvalues)
     except ValueError:
         hub.fatal("arguments must be format NAME=VALUE: %r" %( keyvalues,))
-    # XXX devpi-server 3.0.0 handles the splitting on it's own, this is for
-    # compatibility with older devpi-server
-    for key in ("acl_upload", "bases", "pypi_whitelist"):
-        if key in kvdict:
-            kvdict[key] = [x for x in kvdict[key].split(",") if x]
-    return kvdict

--- a/client/devpi/index.py
+++ b/client/devpi/index.py
@@ -1,16 +1,30 @@
-from devpi.use import parse_keyvalue_spec
+from devpi.use import get_keyvalues
+
 
 def index_create(hub, url, kvdict):
     hub.http_api("put", url, kvdict)
     index_show(hub, url)
 
-def index_modify(hub, url, kvdict):
-    reply = hub.http_api("get", url, type="indexconfig")
-    for name, val in kvdict.items():
-        reply.result[name] = val
-        hub.info("%s changing %s: %s" %(url.path, name, val))
 
-    hub.http_api("patch", url, reply.result)
+def index_modify(hub, url, keyvalues):
+    features = hub.current.features or set()
+    reply = hub.http_api("get", url, type="indexconfig")
+    if 'server-keyvalue-parsing' in features:
+        # the server supports key value parsing
+        patch = keyvalues
+        for op in keyvalues:
+            hub.info("%s %s" % (url.path, op))
+    else:
+        patch = reply.result
+        try:
+            kvdict = keyvalues.kvdict
+        except ValueError as e:
+            hub.fatal(e)
+        for name, val in kvdict.items():
+            patch[name] = val
+            hub.info("%s changing %s: %s" %(url.path, name, val))
+
+    hub.http_api("patch", url, patch)
     index_show(hub, url)
 
 def index_delete(hub, url):
@@ -48,13 +62,16 @@ def parse_posargs(hub, args):
     indexname = args.indexname
     keyvalues = list(args.keyvalues)
     if indexname and "=" in indexname:
-        keyvalues.append(indexname)
+        # indexname is actually a keyvalue, since it comes before the remaining
+        # keyvalues we insert it in first place
+        keyvalues.insert(0, indexname)
         indexname = None
-    kvdict = parse_keyvalue_spec_index(hub, keyvalues)
-    return indexname, kvdict
+    keyvalues = get_keyvalues_index(hub, keyvalues)
+    return indexname, keyvalues
+
 
 def main(hub, args):
-    indexname, kvdict = parse_posargs(hub, args)
+    indexname, keyvalues = parse_posargs(hub, args)
 
     if args.list:
         return index_list(hub, indexname)
@@ -68,14 +85,14 @@ def main(hub, args):
             hub.fatal("cannot delete if you specify key=values")
         return index_delete(hub, url)
     if args.create:
-        return index_create(hub, url, kvdict)
-    if kvdict:
-        return index_modify(hub, url, kvdict)
+        return index_create(hub, url, keyvalues.kvdict)
+    if keyvalues:
+        return index_modify(hub, url, keyvalues)
     else:
         return index_show(hub, url)
 
-def parse_keyvalue_spec_index(hub, keyvalues):
+def get_keyvalues_index(hub, keyvalues):
     try:
-        return parse_keyvalue_spec(keyvalues)
+        return get_keyvalues(keyvalues)
     except ValueError:
         hub.fatal("arguments must be format NAME=VALUE: %r" %( keyvalues,))

--- a/client/devpi/main.py
+++ b/client/devpi/main.py
@@ -117,7 +117,7 @@ class Hub:
         If type is specified and the json result type does not match,
         bail out fatally (unless fatal = False)
         """
-        assert kvdict is None or isinstance(kvdict, dict)
+        assert kvdict is None or isinstance(kvdict, (dict, list))
         if isinstance(url, URL):
             url = url.url
         jsontype = "application/json"

--- a/client/devpi/use.py
+++ b/client/devpi/use.py
@@ -13,6 +13,8 @@ else:
     vbin = "bin"
 
 devpi_endpoints = "index simpleindex pypisubmit login".split()
+devpi_data_keys = ["features"]
+
 
 def currentproperty(name):
     def propget(self):
@@ -33,6 +35,7 @@ class Current(object):
     _client_cert = currentproperty("client_cert")
     always_setcfg = currentproperty("always_setcfg")
     settrusted = currentproperty("settrusted")
+    features = currentproperty("features")
 
     def __init__(self):
         self._currentdict = {}
@@ -249,6 +252,9 @@ class Current(object):
             if val is not None:
                 val = rooturl.joinpath(val).url
             data[name] = val
+        for name in devpi_data_keys:
+            val = result.get(name, None)
+            data[name] = val
         self.reconfigure(data)
         status = result.get("authstatus", None)
         if status and status[0] not in ["ok", "noauth"]:
@@ -391,6 +397,8 @@ def main(hub, args=None):
                     hub.info("%16s: %s" %(name, getattr(current, name)))
             else:
                 hub.info("current devpi index: %s (%s)" % (current.index, login_status))
+                if current.features:
+                    hub.info("supported features: %s" % ", ".join(sorted(current.features)))
         else:
             hub.info("using server: %s (%s)" % (current.rooturl, login_status))
             hub.error("no current index: type 'devpi use -l' "

--- a/client/devpi/use.py
+++ b/client/devpi/use.py
@@ -611,11 +611,18 @@ class BuildoutCfg(BaseCfg):
     default_location = "~/.buildout/default.cfg"
 
 
-def parse_keyvalue_spec(keyvaluelist, keyset=None):
-    d = {}
-    for x in keyvaluelist:
-        key, val = x.split("=", 1)
-        if keyset and key not in keyset:
-            raise KeyError("invalid key: %s, allowed: %s" % (key, keyset))
-        d[key] = val
-    return d
+class KeyValues(list):
+    @property
+    def kvdict(self):
+        kvdict = {}
+        for keyvalue in self:
+            key, value = keyvalue.split("=", 1)
+            kvdict[key] = value
+        return kvdict
+
+
+def get_keyvalues(keyvaluelist):
+    for keyvalue in keyvaluelist:
+        if '=' not in keyvalue:
+            raise ValueError('No equal sign in argument')
+    return KeyValues(keyvaluelist)

--- a/client/devpi/user.py
+++ b/client/devpi/user.py
@@ -1,4 +1,4 @@
-from devpi.use import parse_keyvalue_spec
+from devpi.use import get_keyvalues
 import getpass
 
 
@@ -75,7 +75,7 @@ def main(hub, args):
     username = args.username
     if (args.delete or args.create) and not username:
         hub.fatal("need to specify a username")
-    kvdict = parse_keyvalue_spec(args.keyvalues)
+    kvdict = get_keyvalues(args.keyvalues).kvdict
     if args.create:
         return user_create(hub, username, kvdict)
     elif args.delete:

--- a/client/news/525.feature
+++ b/client/news/525.feature
@@ -1,0 +1,1 @@
+Use server side operations for modifying indexes if the devpi-server version supports it. This prevents overwriting changes if two clients modify the same index concurrently.

--- a/client/testing/test_functional.py
+++ b/client/testing/test_functional.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+from pkg_resources import get_distribution, parse_version
 import json
 import py
 import pytest
@@ -281,28 +282,36 @@ def test_switch_preserves_auth(out_devpi, url_of_liveserver, url_of_liveserver2)
     assert url4 == url1
 
 
+@pytest.fixture
+def new_user_id(gen, mapp):
+    """Create a new user id.
+
+       In case it was used to create a user, that user will be deleted on
+       fixture tear down.
+    """
+    user_id = "tmp_%s_%s" % (gen.user(), str(time.time()))
+    yield user_id
+    try:
+        mapp.delete_user(user=user_id, code=201)
+    except:  # noqa
+        # We need a bare except here, because there are exceptions from
+        # pytest and other places which don't derive from Exception and
+        # listing them all would be long and not future proof
+        pass
+
+
+@pytest.fixture
+def existing_user_id(new_user_id, mapp):
+    """Create a temporary user."""
+    mapp.create_user(
+        user=new_user_id, password=1234,
+        email=new_user_id + "@example.com")
+    return new_user_id
+
+
 class TestUserManagement:
     """ This class tests the user sub command of devpi
     """
-
-    @pytest.fixture
-    def new_user_id(self, request, gen, mapp):
-        user_id = "tmp_%s_%s"  %(gen.user(), str(time.time()))
-        def del_tmp_user():
-            try:
-                mapp.delete_user(user = user_id, code=201)
-            except:
-                pass
-        request.addfinalizer(del_tmp_user)
-        return user_id
-
-    @pytest.fixture
-    def existing_user_id(self, request, new_user_id, mapp):
-        """ Create a temporary user - will be deleted when the
-        fixture is finalized"""
-        mapp.create_user(user=new_user_id, password=1234,
-                         email=new_user_id + "@example.com", code=201)
-        return new_user_id
 
     @pytest.fixture
     def user_list(self, mapp, url_of_liveserver):
@@ -385,3 +394,26 @@ class TestUserManagement:
         """
         mapp.login_root()
         mapp.delete_user(user="root", code=403)
+
+
+devpi_version = get_distribution("devpi-server").parsed_version
+jsonpatch_devpi_version = parse_version("4.7.2dev")
+
+
+@pytest.mark.skipif(
+    devpi_version < jsonpatch_devpi_version,
+    reason="devpi-server without key value parsing support")
+class TestAddRemoveSettings:
+    def test_add_remove_index_list_setting(self, mapp, existing_user_id, url_of_liveserver):
+        mapp.login(user=existing_user_id, password="1234")
+        indexname = '%s/dev' % existing_user_id
+        indexurl = url_of_liveserver.joinpath(indexname)
+        mapp.create_index(indexname)
+        json = mapp.getjson(indexurl)
+        assert json['result']['acl_upload'] == [existing_user_id]
+        mapp.devpi("index", indexname, "acl_upload+=foo")
+        json = mapp.getjson(indexurl)
+        assert 'foo' in json['result']['acl_upload']
+        mapp.devpi("index", indexname, "acl_upload-=foo")
+        json = mapp.getjson(indexurl)
+        assert json['result']['acl_upload'] == [existing_user_id]

--- a/client/testing/test_use.py
+++ b/client/testing/test_use.py
@@ -1,6 +1,6 @@
 from devpi.use import BuildoutCfg, DistutilsCfg, PipCfg
 from devpi.use import Current, PersistentCurrent
-from devpi.use import parse_keyvalue_spec, out_index_list
+from devpi.use import get_keyvalues, out_index_list
 from devpi_common.url import URL
 import pytest
 import re
@@ -506,16 +506,21 @@ class TestUnit:
         assert not hub.current.settrusted
 
 
+def test_getparse_keyvalues_invalid():
+    with pytest.raises(ValueError):
+        get_keyvalues(["hello123"])
+
+
 @pytest.mark.parametrize("input expected".split(), [
     (["hello=123", "world=42"], dict(hello="123", world="42")),
-    (["hello=123=1"], dict(hello="123=1"))
-    ])
-def test_parse_keyvalue_spec(input, expected):
-    result = parse_keyvalue_spec(input, "hello world".split())
-    assert result == expected
+    (["hello=123=1"], dict(hello="123=1")),
+    (["hello=1", "hello=2"], dict(hello="2")),
+    (["hello+=1"], {"hello+": "1"}),
+    (["hello-=1"], {"hello-": "1"})])
+def test_getparse_keyvalues_kvdict(input, expected):
+    result = get_keyvalues(input)
+    assert result.kvdict == expected
 
-def test_parse_keyvalue_spec_unknown_key():
-    pytest.raises(KeyError, lambda: parse_keyvalue_spec(["hello=3"], ["some"]))
 
 def test_user_no_index(loghub):
     out_index_list(loghub, {"user": {"username": "user"}})

--- a/server/devpi_server/hookspecs.py
+++ b/server/devpi_server/hookspecs.py
@@ -20,6 +20,15 @@ def devpiserver_cmdline_run(xom):
 
 
 @hookspec
+def devpiserver_get_features():
+    """ return set containing strings with ids of supported features.
+
+    This is returned in the result of /+api to allow devpi-client to use
+    functionality provided by newer devpi-server versions or added by plugins.
+    """
+
+
+@hookspec
 def devpiserver_storage_backend(settings):
     """ return dict containing storage backend info.
 

--- a/server/devpi_server/main.py
+++ b/server/devpi_server/main.py
@@ -205,7 +205,9 @@ class XOM:
 
     @cached_property
     def supported_features(self):
-        results = set()
+        results = set((
+            'server-keyvalue-parsing',
+        ))
         for features in self.config.hook.devpiserver_get_features():
             results.update(features)
         return tuple(sorted(results))

--- a/server/devpi_server/main.py
+++ b/server/devpi_server/main.py
@@ -204,6 +204,13 @@ class XOM:
         self._stagecache.pop(indexpath, None)
 
     @cached_property
+    def supported_features(self):
+        results = set()
+        for features in self.config.hook.devpiserver_get_features():
+            results.update(features)
+        return tuple(sorted(results))
+
+    @cached_property
     def model(self):
         """ root model object. """
         from devpi_server.model import RootModel

--- a/server/devpi_server/views.py
+++ b/server/devpi_server/views.py
@@ -360,6 +360,7 @@ class PyPIView:
         api = {
             "login": request.route_url('/+login'),
             "authstatus": self.get_auth_status(),
+            "features": self.xom.supported_features,
         }
         if path:
             parts = path.split("/")

--- a/server/devpi_server/views.py
+++ b/server/devpi_server/views.py
@@ -222,6 +222,23 @@ def set_header_devpi_serial(response, tx):
 def is_mutating_http_method(method):
     return method in ("PUT", "POST", "PATCH", "DELETE", "PUSH")
 
+
+def get_actions(json):
+    result = []
+    for item in json:
+        key, sep, value = item.partition('=')
+        if key.endswith('+'):
+            op = 'add'
+            key = key[:-1]
+        elif key.endswith('-'):
+            op = 'del'
+            key = key[:-1]
+        else:
+            op = 'set'
+        result.append((op, key, value))
+    return result
+
+
 class StatusView:
     def __init__(self, request):
         self.request = request
@@ -618,7 +635,28 @@ class PyPIView:
         permission="index_modify")
     def index_modify(self):
         stage = self.context.stage
-        kvdict = getkvdict_index(self.xom.config.hook, getjson(self.request))
+        json = _getjson(self.request)
+        if isinstance(json, list):
+            ixconfig = stage.get()
+            for op, key, value in get_actions(json):
+                if op == 'del':
+                    if value not in ixconfig[key]:
+                        apireturn(
+                            400, "The '%s' setting doesn't have value '%s'" % (key, value))
+                    if isinstance(ixconfig[key], tuple):
+                        ixconfig[key] = tuple(
+                            x for x in ixconfig[key] if x != value)
+                    else:
+                        ixconfig[key].remove(value)
+                elif op == 'add':
+                    if isinstance(ixconfig[key], tuple):
+                        ixconfig[key] += (value,)
+                    else:
+                        ixconfig[key].append(value)
+                elif op == 'set':
+                    ixconfig[key] = value
+            json = ixconfig
+        kvdict = getkvdict_index(self.xom.config.hook, json)
         try:
             ixconfig = stage.modify(**kvdict)
         except InvalidIndexconfig as e:
@@ -1215,16 +1253,25 @@ def url_for_entrypath(request, entrypath):
         route_name, user=user, index=index, relpath=relpath)
 
 
-def getjson(request, allowed_keys=None):
+def _getjson(request):
     try:
-        dict = request.json_body
+        d = request.json_body
     except ValueError:
         abort(request, 400, "Bad request: could not decode json")
+    return d
+
+
+def _check_allowed_keys(request, d, allowed_keys):
+    diff = set(d).difference(allowed_keys)
+    if diff:
+        abort(request, 400, "json keys not recognized: %s" % ",".join(diff))
+
+
+def getjson(request, allowed_keys=None):
+    d = _getjson(request)
     if allowed_keys is not None:
-        diff = set(dict).difference(allowed_keys)
-        if diff:
-            abort(request, 400, "json keys not recognized: %s" % ",".join(diff))
-    return dict
+        _check_allowed_keys(request, d, allowed_keys)
+    return d
 
 
 def abort_if_invalid_filename(request, name, filename):

--- a/server/news/525.feature
+++ b/server/news/525.feature
@@ -1,0 +1,1 @@
+The PATCH method of indexes supports a list of arguments with operations in the form of ``key=value`` for setting values and for lists in the form of ``key+=value`` and ``key-=value`` to add and remove items. This prevents undoing changes sent in concurrent PATCH requests.

--- a/server/test_devpi_server/test_views.py
+++ b/server/test_devpi_server/test_views.py
@@ -517,6 +517,7 @@ def test_apiconfig_features(testapp):
     r = testapp.get_json("/+api")
     assert r.status_code == 200
     assert "features" in r.json["result"]
+    assert "server-keyvalue-parsing" in r.json["result"]["features"]
 
 
 def test_apiconfig_features_plugin(maketestapp, makexom):

--- a/server/test_devpi_server/test_views.py
+++ b/server/test_devpi_server/test_views.py
@@ -513,6 +513,23 @@ def test_apiconfig(testapp):
     assert not "pypisubmit" in r.json["result"]
 
 
+def test_apiconfig_features(testapp):
+    r = testapp.get_json("/+api")
+    assert r.status_code == 200
+    assert "features" in r.json["result"]
+
+
+def test_apiconfig_features_plugin(maketestapp, makexom):
+    class Plugin:
+        def devpiserver_get_features(self):
+            return set(['bar'])
+    xom = makexom(plugins=[Plugin()])
+    testapp = maketestapp(xom)
+    r = testapp.get_json("/+api")
+    assert r.status_code == 200
+    assert "bar" in r.json["result"]["features"]
+
+
 def test_getchanges(testapp):
     # the replica protocol should be disabled by default
     testapp.xget(403, "/+changelog/0")

--- a/server/test_devpi_server/test_views_patch.py
+++ b/server/test_devpi_server/test_views_patch.py
@@ -1,0 +1,51 @@
+import pytest
+
+
+pytestmark = [pytest.mark.notransaction]
+
+
+def test_index_patch(testapp):
+    # add and login user
+    testapp.put_json("/foo", dict(password="123"))
+    testapp.set_auth('foo', '123')
+    # add index
+    testapp.put_json("/foo/dev", dict())
+    r = testapp.get("/foo/dev")
+    # check defaults
+    assert r.json['result'] == {
+        'acl_toxresult_upload': [':ANONYMOUS:'],
+        'acl_upload': ['foo'],
+        'bases': [],
+        'mirror_whitelist': [],
+        'projects': [],
+        'pypi_whitelist': [],
+        'type': 'stage',
+        'volatile': True}
+    # add to acl_upload
+    testapp.patch_json("/foo/dev", ["acl_upload+=bar"])
+    r = testapp.get("/foo/dev")
+    assert r.json['result']['acl_upload'] == ['foo', 'bar']
+    # remove from acl_upload
+    testapp.patch_json("/foo/dev", ["acl_upload-=bar"])
+    r = testapp.get("/foo/dev")
+    assert r.json['result']['acl_upload'] == ['foo']
+    # add to bases
+    testapp.patch_json("/foo/dev", ["bases+=root/pypi"])
+    r = testapp.get("/foo/dev")
+    assert r.json['result']['bases'] == ['root/pypi']
+    # remove from bases
+    testapp.patch_json("/foo/dev", ["bases-=root/pypi"])
+    r = testapp.get("/foo/dev")
+    assert r.json['result']['bases'] == []
+    # add to mirror_whitelist
+    testapp.patch_json("/foo/dev", ["mirror_whitelist+=foo", "mirror_whitelist+=bar"])
+    r = testapp.get("/foo/dev")
+    assert r.json['result']['mirror_whitelist'] == ['foo', 'bar']
+    # remove from mirror_whitelist
+    testapp.patch_json("/foo/dev", ["mirror_whitelist-=foo"])
+    r = testapp.get("/foo/dev")
+    assert r.json['result']['mirror_whitelist'] == ['bar']
+    # remove unknown from mirror_whitelist
+    r = testapp.patch_json("/foo/dev", ["mirror_whitelist-=foo"], expect_errors=True)
+    assert r.status_code == 400
+    assert r.json['message'] == "The 'mirror_whitelist' setting doesn't have value 'foo'"


### PR DESCRIPTION
This prevents undoing changes if two clients modify the same index concurrently.
Additionally it's easier to add and remove items from list values by using ``+=`` and ``-=``.