### PR TITLE
Handle mirrors that don't return a correct X-PYPI-LAST-SERIAL header

### DIFF
--- a/server/devpi_server/extpypi.py
+++ b/server/devpi_server/extpypi.py
@@ -416,7 +416,10 @@ class PyPIStage(BaseStage):
         # Returning a 200 with "no such project" was originally meant to
         # provide earlier versions of easy_install/pip to request the full
         # simple page.
-        serial = int(response.headers.get(str("X-PYPI-LAST-SERIAL"), "-1"))
+        try:
+            serial = int(response.headers.get(str("X-PYPI-LAST-SERIAL")))
+        except:
+            serial = -1
 
         if serial < cache_serial:
             threadlog.warn("serving cached links for %s "

--- a/server/devpi_server/extpypi.py
+++ b/server/devpi_server/extpypi.py
@@ -418,7 +418,8 @@ class PyPIStage(BaseStage):
         # simple page.
         try:
             serial = int(response.headers.get(str("X-PYPI-LAST-SERIAL")))
-        except:
+        except (TypeError, ValueError):
+            # handle missing or invalid X-PYPI-LAST-SERIAL header
             serial = -1
 
         if serial < cache_serial:

--- a/server/news/handle_bad_header.bugfix
+++ b/server/news/handle_bad_header.bugfix
@@ -1,0 +1,1 @@
+handle mirrors that don't return a correct X-PYPI-LAST-SERIAL header.

--- a/server/test_devpi_server/test_views.py
+++ b/server/test_devpi_server/test_views.py
@@ -317,13 +317,19 @@ def test_correct_resolution_order(pypistage, mapp, testapp):
     assert index1.stagename in r.text
 
 def test_simple_page_pypi_serial(pypistage, testapp):
+    # test with no header
     pypistage.mock_simple("hello1", text="qwe", pypiserial=None)
     r = testapp.get("/root/pypi/+simple/hello1/", expect_errors=False)
     assert "X-PYPI-LAST-SERIAL" not in r.headers
+    # test with default serial (10000)
     pypistage.mock_simple("hello2", pkgver="hello2-1.0.zip")
     r = testapp.get("/root/pypi/+simple/hello2/", expect_errors=False)
     assert r.headers.get("X-PYPI-LAST-SERIAL") == '10000'
     assert '/hello2-1.0.zip">hello2-1.0.zip</a>' in r.unicode_body
+    # test with invalid serial
+    pypistage.mock_simple("hello3", text="qwe", pypiserial='foo')
+    r = testapp.get("/root/pypi/+simple/hello3/", expect_errors=False)
+    assert "X-PYPI-LAST-SERIAL" not in r.headers
 
 def test_simple_refresh(mapp, model, pypistage, testapp):
     pypistage.mock_simple("hello", "<html/>")


### PR DESCRIPTION
I'm using a PyPI mirror provides a "None" value for the X-PYPI-LAST-SERIAL in its responses, and I thought others might run into the same issue.