### PR TITLE
Bug fix: Seriously inefficient byte concatenation hindering and breaking streamed downloads #598

### DIFF
--- a/server/devpi_server/filestore.py
+++ b/server/devpi_server/filestore.py
@@ -4,6 +4,7 @@ for all indexes.
 
 """
 from __future__ import unicode_literals
+from io import BytesIO
 import hashlib
 import mimetypes
 from wsgiref.handlers import format_date_time
@@ -294,15 +295,15 @@ class FileEntry(object):
 
         yield self._headers_from_response(r)
 
-        contents = []
+        content = BytesIO()
         while 1:
             data = r.raw.read(10240)
             if not data:
                 break
-            contents.append(data)
+            content.write(data)
             yield data
 
-        content = b''.join(contents)
+        content = content.getvalue()
 
         filesize = len(content)
         if content_size and int(content_size) != filesize:
@@ -365,15 +366,15 @@ class FileEntry(object):
 
         yield self._headers_from_response(r)
 
-        contents = []
+        content = BytesIO()
         while 1:
             data = r.raw.read(10240)
             if not data:
                 break
-            contents.append(data)
+            content.write(data)
             yield data
 
-        content = b''.join(contents)
+        content = content.getvalue()
 
         err = self.check_checksum(content)
         if err:

--- a/server/devpi_server/filestore.py
+++ b/server/devpi_server/filestore.py
@@ -294,13 +294,15 @@ class FileEntry(object):
 
         yield self._headers_from_response(r)
 
-        content = b''
+        contents = []
         while 1:
             data = r.raw.read(10240)
             if not data:
                 break
-            content = content + data
+            contents.append(data)
             yield data
+
+        content = b''.join(contents)
 
         filesize = len(content)
         if content_size and int(content_size) != filesize:
@@ -363,13 +365,15 @@ class FileEntry(object):
 
         yield self._headers_from_response(r)
 
-        content = b''
+        contents = []
         while 1:
             data = r.raw.read(10240)
             if not data:
                 break
-            content = content + data
+            contents.append(data)
             yield data
+
+        content = b''.join(contents)
 
         err = self.check_checksum(content)
         if err:

--- a/server/news/598.bugfix
+++ b/server/news/598.bugfix
@@ -1,0 +1,3 @@
+fix #598: streaming download now uses BytesIO to avoid performance issues for downloads with more than a few MB.
+
+Thanks to Dom Hudson from http://www.thoughtriver.com for the report and initial benchmark code.


### PR DESCRIPTION
## Summary
This is a bug fix for my issue [Bug: Seriously inefficient byte concatenation hindering and breaking streamed downloads #598](https://github.com/devpi/devpi/issues/598)

This should significantly speed up all downloads from pypi (providing they are over the `10240` size) but expontentially affects larger packages.  It also reduces memory and CPU usage.

Please see the issue for more information, but it can be summarised as so:

The original code gets progressively slower in each iteration of this loop (causing large packages to eventually fail).
The fixed code runs at a linear speed and completes the entire download significantly faster.
