### PR TITLE
Feature: Markdown description support

### DIFF
--- a/server/devpi_server/model.py
+++ b/server/devpi_server/model.py
@@ -621,7 +621,9 @@ class PrivateStage(BaseStage):
         'provides', 'requires', 'obsoletes',
         # Metadata 1.2
         'project_urls', 'provides_dist', 'obsoletes_dist',
-        'requires_dist', 'requires_external', 'requires_python')
+        'requires_dist', 'requires_external', 'requires_python',
+        # Metadata 2.1
+        'description_content_type', 'provides_extras')
     metadata_list_fields = (
         'platform', 'classifiers', 'obsoletes',
         'requires', 'provides', 'obsoletes_dist',

--- a/server/news/193.feature
+++ b/server/news/193.feature
@@ -1,0 +1,3 @@
+feature #193: ensuring that the `description_content_type` and `provides_extras` fields are handled.
+
+This is used to add support for using alternative content types in the package descriptions such as `text/markdown`.

--- a/web/devpi_web/description.py
+++ b/web/devpi_web/description.py
@@ -1,42 +1,108 @@
 from __future__ import unicode_literals
 import io
 import py
+import readme_renderer.markdown
 import readme_renderer.rst
 import readme_renderer.txt
 
 
 def get_description(stage, name, version):
-    is_mirror = (stage.ixconfig['type'] == 'mirror')
-    mirror_web_url_fmt = stage.ixconfig.get('mirror_web_url_fmt')
-    if is_mirror and mirror_web_url_fmt is not None:
+    return DescriptionRenderer(
+        stage, name, version).get_description()
+
+
+class DescriptionRenderer:
+
+    DEFAULT_DESCRIPTION = '<p>No description in metadata</p>'
+
+    def __init__(self, stage, name, version):
+        """ Initialiser.
+
+        :return: void
+        """
+        self.name = name
+        self.stage = stage
+        self.version = version
+        self.metadata = self.stage.get_versiondata(
+            self.name, self.version)
+
+    def get_description(self):
+        """ Fetch the desciption.
+
+        :return: string
+        """
+        if self._is_mirror():
+            return self._render_mirror_description()
+        desc = self.metadata.get('description')
+        if not desc:
+            return self._force_text(self.DEFAULT_DESCRIPTION)
+
+        return self._force_text(
+            self._render_description(desc))
+
+    def has_markdown_description(self):
+        """ Does this project specify a markdown content-type?
+
+        :return: boolean
+        """
+        return self.metadata.get(
+            'description_content_type', '').lower() == 'text/markdown'
+
+    @staticmethod
+    def _force_text(html):
+        """ Ensure we return unicode html.
+
+        :return: string
+        """
+        if py.builtin._istext(html):
+            return html
+        return py.builtin._totext(html, 'utf-8')
+
+    def _render_mirror_description(self):
+        """ Generate a description with a link to the remote mirror's description.
+
+        :return: string
+        """
+        link = self._get_mirror_web_url_fmt().format(
+            name=self.name).rstrip('/') + '/%s/' % self.version
+
         html = py.xml.html
-        link = mirror_web_url_fmt.format(name=name)
-        if link.endswith('/'):
-            link = link + "%s/" % version
-        else:
-            link = link + "/%s/" % version
         return html.div(
-            "please refer to description on remote server ",
+            'Please refer to description on remote server ',
             html.a(link, href=link)).unicode(indent=2)
-    metadata = stage.get_versiondata(name, version)
-    desc = metadata.get("description")
-    if desc:
-        html = render_description(stage, desc)
-    else:
-        html = '<p>No description in metadata</p>'
-    if not py.builtin._istext(html):
-        html = py.builtin._totext(html, "utf-8")
-    return html
 
+    def _render_description(self, desc):
+        """ Render a markdown or RST description.
 
-def render_description(stage, desc):
-    warnings = io.StringIO()
-    html = readme_renderer.rst.render(desc, stream=warnings)
-    warnings = warnings.getvalue()
-    if warnings:
-        desc = "%s\n\nRender warnings:\n%s" % (desc, warnings)
-    if html is None:
-        html = readme_renderer.txt.render(desc)
-    if py.builtin._istext(html):
-        html = html.encode("utf8")
-    return html
+        :return: string
+        """
+        warnings = io.StringIO()
+
+        if self.has_markdown_description():
+            html = readme_renderer.markdown.render(desc, stream=warnings)
+        else:
+            html = readme_renderer.rst.render(desc, stream=warnings)
+
+        warnings = warnings.getvalue()
+        if warnings:
+            desc = '%s\n\nRender warnings:\n%s' % (desc, warnings)
+
+        if html is None:
+            html = readme_renderer.txt.render(desc)
+
+        return html
+
+    def _is_mirror(self):
+        """ Is this package a mirror of a remote?
+
+        :return: boolean
+        """
+        return self.stage.ixconfig['type'] == 'mirror' \
+            and self._get_mirror_web_url_fmt() is not None
+
+    def _get_mirror_web_url_fmt(self):
+        """ Fetch the remote's source url.
+
+        :return: string
+        """
+        return self.stage.ixconfig.get('mirror_web_url_fmt')

--- a/web/news/193.feature
+++ b/web/news/193.feature
@@ -1,0 +1,1 @@
+feature #193: adding support for using markdown in package descriptions.


### PR DESCRIPTION
## Summary
Adding support for using markdown in package descriptions.

Enabled by existing functionality in [`readme_renderer`](https://github.com/pypa/readme_renderer/pull/55)

## Use
Simply add markdown to the existing the `long_description` field and set the `long_description_content_type` field to 'text/markdown'.

## Closes
https://github.com/devpi/devpi/issues/193

## Notes
The tox tests are failing on my local with py2.7 but passing if I run them manually with pytest and the same version of python. I believe this is because it is installing the unmodified devpi-server as part of the spinning up the 2.7 which doesn't contain the additional `long_description_content_type` field but may be wrong - feedback welcome.

I was a little confused by the stuff going on with `py.bultin._istext` and `py.bultin._totext` [here](https://github.com/devpi/devpi/blob/master/web/devpi_web/description.py#L27). In some cases, it seemed to encode the html as utf-8 and then decode it straight back again.

I've left it in as `devpi_web.description.DescriptionRenderer._force_text`.
