### PR TITLE
Added option '--root-passwd' which takes a string argument to be the …

### DIFF
--- a/client/devpi/main.py
+++ b/client/devpi/main.py
@@ -733,7 +733,7 @@ def user(parser):
         help="user name")
     parser.add_argument("keyvalues", nargs="*", type=str,
         help="key=value configuration item.  Possible keys: "
-             "email, password.")
+             "email, password and pwhash.")
 
 
 @subcommand("devpi.user:passwd")

--- a/client/devpi/user.py
+++ b/client/devpi/user.py
@@ -18,7 +18,7 @@ def getnewpass(hub, username):
         hub.error("passwords did not match")
 
 def user_create(hub, user, kvdict):
-    if "password" not in kvdict:
+    if "password" not in kvdict and "pwhash" not in kvdict:
         kvdict["password"] = getnewpass(hub, user)
     hub.http_api("put", hub.current.get_user_url(user), kvdict)
     hub.info("user created: %s" % user)

--- a/client/news/93.feature
+++ b/client/news/93.feature
@@ -1,0 +1,1 @@
+implement #93: support setting password hash with devpi-server 4.9.0.

--- a/server/devpi_server/config.py
+++ b/server/devpi_server/config.py
@@ -187,6 +187,11 @@ def addoptions(parser, pluginmanager):
             help="initial password for the root user. This option has no "
                  "effect if the user 'root' already exist.")
 
+    deploy.addoption("--root-passwd-hash", type=str, default=None,
+            help="initial password hash for the root user. "
+                 "This option has no effect if the user 'root' already "
+                 "exist.")
+
     backends = sorted(
         pluginmanager.hook.devpiserver_storage_backend(settings=None),
         key=itemgetter("name"))

--- a/server/devpi_server/config.py
+++ b/server/devpi_server/config.py
@@ -183,6 +183,10 @@ def addoptions(parser, pluginmanager):
                  "improve performance. Each entry uses 1kb of memory on "
                  "average. So by default about 10MB are used.")
 
+    deploy.addoption("--root-passwd", type=str, default="",
+            help="initial password for the root user. This option has no "
+                 "effect if the user 'root' already exist.")
+
     backends = sorted(
         pluginmanager.hook.devpiserver_storage_backend(settings=None),
         key=itemgetter("name"))

--- a/server/devpi_server/main.py
+++ b/server/devpi_server/main.py
@@ -470,7 +470,9 @@ def apifatal(request, *args, **kwargs):
 def set_default_indexes(model):
     root_user = model.get_user("root")
     if not root_user:
-        root_user = model.create_user("root", "")
+        root_user = model.create_user(
+            "root",
+            model.xom.config.args.root_passwd)
         threadlog.info("created root user")
     userconfig = root_user.key.get(readonly=False)
     indexes = userconfig["indexes"]

--- a/server/devpi_server/main.py
+++ b/server/devpi_server/main.py
@@ -472,7 +472,8 @@ def set_default_indexes(model):
     if not root_user:
         root_user = model.create_user(
             "root",
-            model.xom.config.args.root_passwd)
+            model.xom.config.args.root_passwd,
+            pwhash=model.xom.config.args.root_passwd_hash)
         threadlog.info("created root user")
     userconfig = root_user.key.get(readonly=False)
     indexes = userconfig["indexes"]

--- a/server/news/93.feature
+++ b/server/news/93.feature
@@ -1,1 +1,1 @@
-implement #93: allow setting root user password during initialization with ``--root-passwd`` option. Thanks to Andreas Palsson.
+implement #93: When creating a user, the password hash can be set directly with ``pwhash``. Upon database initialization allow setting root user password with ``--root-passwd`` and the password hash with ``--root-passwd-hash`` options. Thanks to Andreas Palsson.

--- a/server/news/93.feature
+++ b/server/news/93.feature
@@ -1,0 +1,1 @@
+implement #93: allow setting root user password during initialization with ``--root-passwd`` option. Thanks to Andreas Palsson.

--- a/server/test_devpi_server/test_main.py
+++ b/server/test_devpi_server/test_main.py
@@ -286,3 +286,18 @@ def test_root_passwd_option(makexom):
         user = xom.model.get_user('root')
         assert not user.validate("")
         assert user.validate("foobar")
+
+
+def test_root_passwd_hash_option(makexom):
+    # by default the password is empty
+    xom = makexom()
+    with xom.keyfs.transaction(write=False):
+        user = xom.model.get_user('root')
+        assert user.validate("")
+        assert not user.validate("foobar")
+    # the password hash can be directly set from the command line
+    xom = makexom(["--root-passwd-hash", "$argon2i$v=19$m=102400,t=2,p=8$j9G6V8o5B0Co9f4fQ6gVIg$WzcG2C5Bv0LwtzPWeBcz0g"])
+    with xom.keyfs.transaction(write=False):
+        user = xom.model.get_user('root')
+        assert not user.validate("")
+        assert user.validate("foobar")

--- a/server/test_devpi_server/test_main.py
+++ b/server/test_devpi_server/test_main.py
@@ -271,3 +271,18 @@ def test_serve_max_body(monkeypatch, tmpdir):
     monkeypatch.setattr("waitress.serve", check_max_body)
     from devpi_server.main import main
     main(["devpi-server", "--max-request-body-size", "42"])
+
+
+def test_root_passwd_option(makexom):
+    # by default the password is empty
+    xom = makexom()
+    with xom.keyfs.transaction(write=False):
+        user = xom.model.get_user('root')
+        assert user.validate("")
+        assert not user.validate("foobar")
+    # the password can be set from the command line
+    xom = makexom(["--root-passwd", "foobar"])
+    with xom.keyfs.transaction(write=False):
+        user = xom.model.get_user('root')
+        assert not user.validate("")
+        assert user.validate("foobar")

--- a/server/test_devpi_server/test_model.py
+++ b/server/test_devpi_server/test_model.py
@@ -955,6 +955,16 @@ class TestUsers:
         assert 'pwsalt' not in userconfig
         assert userconfig['pwhash'].startswith("$argon2")
 
+    def test_create_with_hash(self, model):
+        user = model.get_user("user")
+        assert not user
+        user = model.create_user(
+            "user", None,
+            pwhash="$argon2i$v=19$m=102400,t=2,p=8$F2JMqVVKSSnFGEPIGQOAsA$RXW/kJM94gq00l9QWDG0OA")
+        assert user
+        assert user.validate("password")
+        assert not user.validate("password2")
+
     def test_create_and_delete(self, model):
         user = model.create_user("user", password="password")
         user.delete()


### PR DESCRIPTION
This patch adds a new command line option, `--root-passwd`, which takes one string argument to use as the initial root password instead of an empty string.  
If the root account already exist, this option has no effect.

This change makes it easier to initially deploy the server in environments without interactive terminals, such as Docker where the initial password can be supplied via environment variables.


