### PR TITLE
Fix #622: Skip remove if the ver comes from a base

### DIFF
--- a/client/devpi/list_remove.py
+++ b/client/devpi/list_remove.py
@@ -146,7 +146,8 @@ def main_remove(hub, args):
     if confirm_delete(hub, ver_to_delete):
         for ver, links in ver_to_delete:
             hub.info("deleting release %s of %s" % (ver, req.project_name))
-            hub.http_api("delete", proj_url.addpath(ver))
+            if links:
+                hub.http_api("delete", proj_url.addpath(ver))
     else:
         hub.error("not deleting anything")
 


### PR DESCRIPTION
When removing a package, the client used to try and delete all versions found, even those residing in one of the bases.  Sorry for not writing tests, but it's really a trivial fix and if you think I have to, please point me to a sample test I can copy, preferably one with a setup that includes two indexes where one is the base of the other.

Thanks for a great tool!

Benny