### PR TITLE
Fix #622: deletion of package with inherited versions failed.

### DIFF
--- a/client/devpi/list_remove.py
+++ b/client/devpi/list_remove.py
@@ -144,9 +144,14 @@ def main_remove(hub, args):
             "No releases or distributions found matching '%s'." % args.spec_or_url)
         return 1
     if confirm_delete(hub, ver_to_delete):
-        for ver, links in ver_to_delete:
-            hub.info("deleting release %s of %s" % (ver, req.project_name))
-            hub.http_api("delete", proj_url.addpath(ver))
+        if req.specs:
+            # delete specific versions
+            for ver, links in ver_to_delete:
+                hub.info("deleting release %s of %s" % (ver, req.project_name))
+                hub.http_api("delete", proj_url.addpath(ver))
+        else:
+            # delete whole project
+            hub.http_api("delete", proj_url)
     else:
         hub.error("not deleting anything")
 

--- a/client/news/622.bugfix
+++ b/client/news/622.bugfix
@@ -1,0 +1,1 @@
+fix #622: deletion of package with inherited versions failed.

--- a/client/testing/test_list_remove.py
+++ b/client/testing/test_list_remove.py
@@ -190,3 +190,31 @@ class TestListRemove:
         assert len([x for x in out.stdout.lines if x.strip()]) == 0
         out = out_devpi("list", "--index", "%s/dev" % user, "-v")
         assert len([x for x in out.stdout.lines if x.strip()]) == 0
+
+    def test_delete_version_with_inheritance(self, initproj, devpi, out_devpi, simpypi):
+        devpi("index", "bases=root/pypi", "mirror_whitelist=*")
+        initproj("dddttt-0.666", {"doc": {
+            "conf.py": "",
+            "index.html": "<html/>"}})
+        assert py.path.local("setup.py").check()
+        devpi("upload", "--formats", "sdist.zip")
+        out = out_devpi("list", "dddttt", "--all")
+        out.stdout.fnmatch_lines_random("*/dev/*/dddttt-0.666.zip")
+        out = out_devpi("remove", "dddttt==0.666", code=200)
+        out = out_devpi("list", "dddttt", "--all")
+        with pytest.raises(ValueError):
+            out.stdout.fnmatch_lines_random("*/dev/*/dddttt-0.666.zip")
+
+    def test_delete_project_with_inheritance(self, initproj, devpi, out_devpi, simpypi):
+        devpi("index", "bases=root/pypi", "mirror_whitelist=*")
+        initproj("dddttt-0.666", {"doc": {
+            "conf.py": "",
+            "index.html": "<html/>"}})
+        assert py.path.local("setup.py").check()
+        devpi("upload", "--formats", "sdist.zip")
+        out = out_devpi("list", "dddttt", "--all")
+        out.stdout.fnmatch_lines_random("*/dev/*/dddttt-0.666.zip")
+        out = out_devpi("remove", "dddttt", code=200)
+        out = out_devpi("list", "dddttt", "--all")
+        with pytest.raises(ValueError):
+            out.stdout.fnmatch_lines_random("*/dev/*/dddttt-0.666.zip")


### PR DESCRIPTION
When deleting a whole package without version specifier, then devpi would try to delete all versions, this included inherited versions which failed.
Now devpi deletes the whole package server side, which does the right thing.