### PR TITLE
Docs: More details on using YAML configuration file.

### DIFF
--- a/doc/quickstart-server.rst
+++ b/doc/quickstart-server.rst
@@ -44,7 +44,12 @@ Using a configuration file for devpi-server
 
 A `strict YAML`_ conform configuration file can be used in place of the command line options.
 
-The configuration file will be looked for in your systems and your users default configuration location using the `appdirs`_ library.
+A configuration file named ``devpi-server.yml`` will be looked for in your systems and your users default configuration location using the `appdirs`_ library.
+
+.. note::
+
+    For ``appdirs`` the application name is ``devpi-server``, and the application author is ``devpi``.
+    Thus, for example, on Linux the user configuration file would be ``~/.config/devpi-server/devpi-server.yml``.
 
 With the `-c/--configfile` option the location can be provided explicitly.
 


### PR DESCRIPTION
I had to look through some source code to figure out the specifics on the file and application names used with *appdirs* in order to use a YAML configuration file.  It seemed like the docs would benefit from having that information spelled out so I'm submitting this PR.