### PR TITLE
fixing devpi web error when info about more than 10 replication error

### DIFF
--- a/web/devpi_web/views.py
+++ b/web/devpi_web/views.py
@@ -729,8 +729,8 @@ def statusview(request):
     replication_errors = []
     for index, error in enumerate(status.get('replication-errors', {}).values()):
         replication_errors.append(error)
-        if index >= 10:
-            replication_errors.append(dict(message="More than 10 replication errors."))
+    if len(replication_errors) >= 10:
+        replication_errors.append(dict(message="More than 10 replication errors."))
     _polling_replicas = status.get('polling_replicas', {})
     polling_replicas = []
     for replica_uuid in sorted(_polling_replicas):


### PR DESCRIPTION
Hi Florian,

I added a quick fix to one issue in devpi-web I noticed recently - when number of replication errors is more than 10, then for each error with index greater than 10 an extra message "More than 10 replication errors" is added. This fix makes sure it is added only once.

Unfortunately I did not find any unit tests covering replication errors. I can add one if needed - please let me know how to handle it. Thanks!