### PR TITLE
Remove test stuff from devpi-client's packaging

### DIFF
--- a/client/setup.py
+++ b/client/setup.py
@@ -26,14 +26,15 @@ if __name__ == "__main__":
     README = io.open(os.path.join(here, 'README.rst'), encoding='utf-8').read()
     CHANGELOG = get_changelog()
 
-    install_requires=["tox>=3.1.0",
-                      "devpi_common<4,>=3.4.0",
+    install_requires=["devpi_common<4,>=3.4.0",
                       "pkginfo>=1.4.2",
                       "check-manifest>=0.28",
                       "pluggy>=0.6.0,<1.0",
                       "py>=1.4.31"]
 
-    extras_require = {}
+    extras_require = {
+        "test": ["tox>=3.1.0"],
+    }
 
     setup(
       name="devpi-client",
@@ -41,7 +42,7 @@ if __name__ == "__main__":
                   "developers",
       long_description="\n\n".join([README, CHANGELOG]),
       version='5.1.0',
-      packages=find_packages(),
+      packages=find_packages(exclude=["testing"]),
       install_requires=install_requires,
       extras_require=extras_require,
       url="https://github.com/devpi/devpi",

--- a/client/tox.ini
+++ b/client/tox.ini
@@ -15,6 +15,7 @@ envlist = py27-server4,py27-version,py27,py27-lin,py34,py35,pypy
 
 [testenv]
 passenv = LANG
+extras = test
 deps = pytest
        pytest-flake8
        pytest-instafail


### PR DESCRIPTION
Closes https://github.com/devpi/devpi/issues/746 

- Make the tox dependency optional.  Can use `pip install devpi-client[test]` to pull it in.
- Don't export a `testing` package to site-packages on `pip install devpi-client` 

```
$ ls ~/.venv/lib/python3.8/site-packages/testing
conftest.py    __init__.py  reqmock.py  test_functional.py  test_install.py      test_login.py  test_push.py    test_test.py    test_use.py
functional.py  __pycache__  simpypi.py  test_index.py       test_list_remove.py  test_main.py   test_pypirc.py  test_upload.py  test_user.py
```