### PR TITLE
Fix content-type header when empty string

### DIFF
--- a/server/devpi_server/views.py
+++ b/server/devpi_server/views.py
@@ -1324,8 +1324,8 @@ def should_fetch_remote_file(entry, headers):
 def _headers_from_response(r):
     headers = {
         str("X-Accel-Buffering"): str("no"),  # disable buffering in nginx
-        str("content-type"): r.headers.get(
-            "content-type", (str("application/octet-stream"), None))[0]}
+        str("content-type"): (r.headers.get(
+            "content-type") or (str("application/octet-stream"), None))[0]}
     if "last-modified" in r.headers:
         headers[str("last-modified")] = r.headers["last-modified"]
     if "content-length" in r.headers:

--- a/server/news/header-content-type.bugfix
+++ b/server/news/header-content-type.bugfix
@@ -1,0 +1,1 @@
+Handle cases where the ``Content-Type`` header can be an empty string.

--- a/server/test_devpi_server/test_filestore.py
+++ b/server/test_devpi_server/test_filestore.py
@@ -234,6 +234,20 @@ class TestFileStore:
         assert rheaders["content-type"] in zip_types
         assert entry.file_get_content() == b"123"
 
+    def test_iterfile_remote_empty_content_type_header(self, filestore, httpget, gen, xom):
+        link = gen.pypi_package_link("pytest-1.8.zip", md5=False)
+        entry = filestore.maplink(link, "root", "pypi", "pytest")
+        assert not entry.hash_spec
+        headers={"Content-Type": ""}
+        httpget.url2response[link.url] = dict(status_code=200,
+                headers=headers, raw = BytesIO(b"123"))
+        for part in iter_cache_remote_file(xom, entry):
+            pass
+        rheaders = entry.gethttpheaders()
+        assert rheaders["content-length"] == "3"
+        assert rheaders["content-type"] in zip_types
+        assert entry.file_get_content() == b"123"
+
     def test_iterfile_remote_error_size_mismatch(self, filestore, httpget, gen, xom):
         link = gen.pypi_package_link("pytest-3.0.zip", md5=False)
         entry = filestore.maplink(link, "root", "pypi", "pytest")


### PR DESCRIPTION
When trying to install a package from an index mirroring a private PyPI server, the `Content-Type` header is an empty string, which triggers an `Index out of range` error.

I checked with a debugger and `r.headers.get("content-type")` returns `''` instead of a tuple, and thus `''[0]` is executed and throws the exception.

Unfortunately I can't publish the URL that it is requesting as it contains private information, but it is an AWS S3 URL that looks like this: `https://<organization>.s3.amazonaws.com/package.name/package.name-version-py2-none-any.whl?AWSAccessKeyId=<redacted>&Signature=<redacted>&Expires=<redacted>`

This is the traceback:
```python
Traceback (most recent call last):
File "/usr/local/lib/python3.8/site-packages/pyramid/tweens.py", line 13, in _error_handler
  response = request.invoke_exception_view(exc_info)
File "/usr/local/lib/python3.8/site-packages/pyramid/view.py", line 779, in invoke_exception_view
  raise HTTPNotFound
pyramid.httpexceptions.HTTPNotFound: The resource could not be found.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
File "/usr/local/lib/python3.8/site-packages/waitress/channel.py", line 349, in service
  task.service()
File "/usr/local/lib/python3.8/site-packages/waitress/task.py", line 169, in service
  self.execute()
File "/usr/local/lib/python3.8/site-packages/waitress/task.py", line 439, in execute
  app_iter = self.channel.server.application(environ, start_response)
File "/usr/local/lib/python3.8/site-packages/devpi_server/views.py", line 154, in __call__
  return self.app(environ, start_response)
File "/usr/local/lib/python3.8/site-packages/pyramid/router.py", line 270, in __call__
  response = self.execution_policy(environ, self)
File "/usr/local/lib/python3.8/site-packages/pyramid/router.py", line 279, in default_execution_policy
  return request.invoke_exception_view(reraise=True)
File "/usr/local/lib/python3.8/site-packages/pyramid/view.py", line 778, in invoke_exception_view
  reraise_(*exc_info)
File "/usr/local/lib/python3.8/site-packages/pyramid/compat.py", line 179, in reraise
  raise value
File "/usr/local/lib/python3.8/site-packages/pyramid/router.py", line 277, in default_execution_policy
  return router.invoke_request(request)
File "/usr/local/lib/python3.8/site-packages/pyramid/router.py", line 249, in invoke_request
  response = handle_request(request)
File "/usr/local/lib/python3.8/site-packages/devpi_server/views.py", line 178, in request_log_handler
  response = handler(request)
File "/usr/local/lib/python3.8/site-packages/devpi_server/views.py", line 215, in request_tx_handler
  response = handler(request)
File "/usr/local/lib/python3.8/site-packages/pyramid/tweens.py", line 43, in excview_tween
  response = _error_handler(request, exc)
File "/usr/local/lib/python3.8/site-packages/pyramid/tweens.py", line 17, in _error_handler
  reraise(*exc_info)
File "/usr/local/lib/python3.8/site-packages/pyramid/compat.py", line 179, in reraise
  raise value
File "/usr/local/lib/python3.8/site-packages/pyramid/tweens.py", line 41, in excview_tween
  response = handler(request)
File "/usr/local/lib/python3.8/site-packages/pyramid/router.py", line 147, in handle_request
  response = _call_view(
File "/usr/local/lib/python3.8/site-packages/pyramid/view.py", line 667, in _call_view
  response = view_callable(context, request)
File "/usr/local/lib/python3.8/site-packages/pyramid/config/views.py", line 169, in __call__
  return view(context, request)
File "/usr/local/lib/python3.8/site-packages/pyramid/viewderivers.py", line 401, in viewresult_to_response
  result = view(context, request)
File "/usr/local/lib/python3.8/site-packages/pyramid/viewderivers.py", line 116, in _class_requestonly_view
  response = getattr(inst, attr)()
File "/usr/local/lib/python3.8/site-packages/devpi_server/views.py", line 1185, in mirror_pkgserv
  return self._pkgserv(entry)
File "/usr/local/lib/python3.8/site-packages/devpi_server/views.py", line 1159, in _pkgserv
  headers = next(app_iter)
File "/usr/local/lib/python3.8/site-packages/devpi_server/views.py", line 1480, in iter_fetch_remote_file
  for part in iter_cache_remote_file(xom, entry):
File "/usr/local/lib/python3.8/site-packages/devpi_server/views.py", line 1347, in iter_cache_remote_file
  yield _headers_from_response(r)
File "/usr/local/lib/python3.8/site-packages/devpi_server/views.py", line 1327, in _headers_from_response
  str("content-type"): r.headers.get(
```