### PR TITLE
Fix tests: do not rely on os.listdir order

### DIFF
--- a/server/test_devpi_server/test_importexport.py
+++ b/server/test_devpi_server/test_importexport.py
@@ -111,7 +111,7 @@ def test_export_import(tmpdir, capfd, monkeypatch):
         export_dir.strpath])
     assert ret == 0
     out, err = capfd.readouterr()
-    assert os.listdir(clean.strpath) == os.listdir(import_dir.strpath)
+    assert sorted(os.listdir(clean.strpath)) == sorted(os.listdir(import_dir.strpath))
     assert 'import_all: importing finished' in out
     assert err == ''
 
@@ -142,7 +142,7 @@ def test_export_import_no_root_pypi(tmpdir, capfd, monkeypatch):
         export_dir.strpath])
     assert ret == 0
     out, err = capfd.readouterr()
-    assert os.listdir(clean.strpath) == os.listdir(import_dir.strpath)
+    assert sorted(os.listdir(clean.strpath)) == sorted(os.listdir(import_dir.strpath))
     assert 'import_all: importing finished' in out
     assert err == ''
     # now we add --no-root-pypi
@@ -155,7 +155,7 @@ def test_export_import_no_root_pypi(tmpdir, capfd, monkeypatch):
         export_dir.strpath])
     assert ret == 0
     out, err = capfd.readouterr()
-    assert os.listdir(clean.strpath) == os.listdir(import_dir.strpath)
+    assert sorted(os.listdir(clean.strpath)) == sorted(os.listdir(import_dir.strpath))
     assert 'import_all: importing finished' in out
     assert err == ''
 


### PR DESCRIPTION
os.listdir returns an arbitrary ordered list of files [1]

Here is an example of failing tests due to this non ordered: https://hydra.nixos.org/build/127650244/nixlog/2

[1] https://docs.python.org/3/library/os.html#os.listdir