### PR TITLE
📚 Fix docs typo

### DIFF
--- a/doc/userman/devpi_concepts.rst
+++ b/doc/userman/devpi_concepts.rst
@@ -124,7 +124,7 @@ Indexes
 
 - A index is **volatile** if packages can be overridden with the same version 
   (which would make sense for a development index). Otherwise, attempting to 
-  *upload* [#f2]_ a package with the same version would result in an error. 
+  *upload* [#f1]_ a package with the same version would result in an error. 
   See the :ref:`non_volatile_indexes` for rules specific to this index type. 
    
 - A user can have/create as many indices as he/she wants. 
@@ -133,7 +133,7 @@ Indexes
 
    Suppose that Sophie has the same index hierarchy as Emilie (*/sophie/prod* -> */sophie/dev*) 
    but wants to experiment with a package Emilie is currently working on and stored in */emilie/dev*, 
-   Sophie could create a sub index */sophie/fiddle*, using both her and Emilie's dev index [#f3]_,
+   Sophie could create a sub index */sophie/fiddle*, using both her and Emilie's dev index [#f2]_,
    which would look like::
    
       $ devpi getjson http://localhost:3141/sophie
@@ -234,13 +234,11 @@ Server End Points
 
 .. rubric:: Footnotes
 
-.. [#f1] this is true, when you run devpi and the ``devpi server`` on you local machine. 
-
-.. [#f2] **Uploading** refers to storing a package in an index whereas **pushing** refers to *transferring* 
+.. [#f1] **Uploading** refers to storing a package in an index whereas **pushing** refers to *transferring* 
          a package from one index to another. In the example above, Emilie would **upload** package 
          *foo* to */emilie/dev* and later on **push** the package from */emilie/dev* to */emilie/prod*.
          
-.. [#f3] A preferred option in this case would be to temporarily modify the base of sophie's dev index:
+.. [#f2] A preferred option in this case would be to temporarily modify the base of sophie's dev index:
 
             ``devpi index -m dev bases=/sophie/prod,/emilie/dev volatile=True``       
 

--- a/doc/userman/devpi_concepts.rst
+++ b/doc/userman/devpi_concepts.rst
@@ -31,7 +31,7 @@ Overview
 
 The `devpi`_ consists of two parts:
 
-   - A ``devpi server`` responsible for providing a PyPI index cache and to manager sub-indices.
+   - A ``devpi server`` responsible for providing a PyPI index cache and to manage sub-indices.
      The ``devpi server`` is compatible with most python installer tools. 
      
    - The ``devpi client`` provides the user interface (command line) to interface with the ``devpi server``.

--- a/doc/userman/devpi_packages.rst
+++ b/doc/userman/devpi_packages.rst
@@ -154,7 +154,7 @@ We can verify that we uploaded two versions of our release file::
 Removing A Release File (or project)
 ------------------------------------
 
-.. note:: The following only work from :term:`volatile` indexes. This is a safeguard
+.. note:: The following only works from :term:`volatile` indexes. This is a safeguard
           to prevent deleting production indexes. 
    
 If the :term:`release file` version 0.0.2 was uploaded by error, it can easily be 

--- a/doc/userman/devpi_user.rst
+++ b/doc/userman/devpi_user.rst
@@ -53,7 +53,7 @@ More on the use command can be found :ref:`here <devpi_um_indices_use_section>`
 Creating a User
 ---------------
 
-If the do not already have a user ID he or she must create one::
+If the user does not already have a user ID he or she must create one::
 
    $ devpi user -c emilie email=edoe@mydomain.net password=1234
    user created: emilie


### PR DESCRIPTION
- Fix Minor typo 
- Update footnotes removing old reference that no longer existed since 03dd0de