### PR TITLE
Avoid attribute error when route is None

### DIFF
--- a/server/devpi_server/views.py
+++ b/server/devpi_server/views.py
@@ -471,6 +471,8 @@ class PyPIView:
         info = routes_mapper(orig_request)
         (orig_request.matchdict, orig_request.matched_route) = (
             info['match'], info['route'])
+        if orig_request.matched_route is None:
+            return HTTPForbidden()
         root_factory = orig_request.matched_route.factory or root_factory
         orig_request.context = root_factory(orig_request)
         with RequestContext(orig_request):

--- a/server/test_devpi_server/test_authcheck.py
+++ b/server/test_devpi_server/test_authcheck.py
@@ -56,3 +56,18 @@ def test_authcheck_always_ok(testapp):
         200, 'http://localhost/+authcheck',
         headers=ResponseHeaders({
             'X-Original-URI': 'http://localhost/+login'}))
+
+
+def test_authcheck_404(testapp):
+    testapp.xget(
+        403, 'http://localhost/+authcheck',
+        headers=ResponseHeaders({
+            'X-Original-URI': 'http://localhost/+unavailable_route/'}))
+    testapp.xget(
+        403, 'http://localhost/+authcheck',
+        headers=ResponseHeaders({
+            'X-Original-URI': 'http://localhost/user/+unavailable_route/'}))
+    testapp.xget(
+        403, 'http://localhost/+authcheck',
+        headers=ResponseHeaders({
+            'X-Original-URI': 'http://localhost/user/index/+unavailable_route/'}))


### PR DESCRIPTION
I've noticed the following exception in our logs.  I'm not familiar with pyramid and have no idea how to add a test for this.  If you can point me in the right direction, I'm happy to add one. :)

```
2021-10-06 15:25:04,653 ERROR Exception while serving /+authcheck
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/pyramid/tweens.py", line 13, in _error_handler
    response = request.invoke_exception_view(exc_info)
  File "/usr/local/lib/python3.9/site-packages/pyramid/view.py", line 786, in invoke_exception_view
    raise HTTPNotFound
pyramid.httpexceptions.HTTPNotFound: The resource could not be found.
​
During handling of the above exception, another exception occurred:
​
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/waitress/channel.py", line 397, in service
    task.service()
  File "/usr/local/lib/python3.9/site-packages/waitress/task.py", line 168, in service
    self.execute()
  File "/usr/local/lib/python3.9/site-packages/waitress/task.py", line 434, in execute
    app_iter = self.channel.server.application(environ, start_response)
  File "/usr/local/lib/python3.9/site-packages/devpi_server/views.py", line 166, in __call__
    return self.app(environ, start_response)
  File "/usr/local/lib/python3.9/site-packages/pyramid/router.py", line 270, in __call__
    response = self.execution_policy(environ, self)
  File "/usr/local/lib/python3.9/site-packages/pyramid/router.py", line 276, in default_execution_policy
    return router.invoke_request(request)
  File "/usr/local/lib/python3.9/site-packages/pyramid/router.py", line 245, in invoke_request
    response = handle_request(request)
  File "/usr/local/lib/python3.9/site-packages/devpi_server/views.py", line 190, in request_log_handler
    response = handler(request)
  File "/usr/local/lib/python3.9/site-packages/devpi_server/views.py", line 226, in request_tx_handler
    response = handler(request)
  File "/usr/local/lib/python3.9/site-packages/pyramid/tweens.py", line 43, in excview_tween
    response = _error_handler(request, exc)
  File "/usr/local/lib/python3.9/site-packages/pyramid/tweens.py", line 17, in _error_handler
    reraise(*exc_info)
  File "/usr/local/lib/python3.9/site-packages/pyramid/util.py", line 733, in reraise
    raise value
  File "/usr/local/lib/python3.9/site-packages/pyramid/tweens.py", line 41, in excview_tween
    response = handler(request)
  File "/usr/local/lib/python3.9/site-packages/pyramid/router.py", line 143, in handle_request
    response = _call_view(
  File "/usr/local/lib/python3.9/site-packages/pyramid/view.py", line 674, in _call_view
    response = view_callable(context, request)
  File "/usr/local/lib/python3.9/site-packages/pyramid/viewderivers.py", line 392, in viewresult_to_response
    result = view(context, request)
  File "/usr/local/lib/python3.9/site-packages/pyramid/viewderivers.py", line 113, in _class_requestonly_view
    response = getattr(inst, attr)()
  File "/usr/local/lib/python3.9/site-packages/devpi_server/views.py", line 490, in authcheck_view
    root_factory = orig_request.matched_route.factory or root_factory
AttributeError: 'NoneType' object has no attribute 'factory'
```