### PR TITLE
Add missing dependency to devpi-server

### DIFF
--- a/server/news/missing-dependency.bugfix
+++ b/server/news/missing-dependency.bugfix
@@ -1,0 +1,2 @@
+- Add missing `lazy` package dependency. Previously this was only a transitive
+dependency coming from the devpi-common package.

--- a/server/setup.py
+++ b/server/setup.py
@@ -41,6 +41,7 @@ if __name__ == "__main__":
                         "pluggy>=0.6.0,<2.0",
                         'ruamel.yaml',
                         "strictyaml",
+                        "lazy",
                         ]
     extras_require = {}
 


### PR DESCRIPTION
`lazy` is used within devpi-server but was depending on it as a
transitive dependency from the devpi-common>=3.5.0 package being
available.

* [Example import of `lazy` in devpi-server v6.2.0](https://github.com/devpi/devpi/blob/main/server/devpi_server/views.py#L18)