### PR TITLE
Async simplelinks

### DIFF
--- a/server/devpi_server/extpypi.py
+++ b/server/devpi_server/extpypi.py
@@ -18,8 +18,10 @@ from devpi_common.validation import normalize_name
 from functools import partial
 from html.parser import HTMLParser
 from .config import hookimpl
+from .exceptions import lazy_format_exception
+from .filestore import key_from_link
 from .model import BaseStageCustomizer
-from .model import BaseStage, make_key_and_href, SimplelinkMeta
+from .model import BaseStage, SimplelinkMeta
 from .model import ensure_boolean
 from .model import join_links_data
 from .readonly import ensure_deeply_readonly
@@ -403,6 +405,112 @@ class PyPIStage(BaseStage):
         self.key_projsimplelinks(project).set({})
         threadlog.debug("cleared cache for %s", project)
 
+    def _fetch_releaselinks(self, project, cache_serial):
+        # get the simple page for the project
+        url = self.mirror_url + project + "/"
+        threadlog.debug("reading index %s", url)
+        response = self.httpget(url, allow_redirects=True, timeout=self.timeout)
+        if response.status_code != 200:
+            if response.status_code == 404:
+                self.cache_retrieve_times.refresh(project)
+                raise self.UpstreamNotFoundError(
+                    "not found on GET %s" % url)
+
+            # we don't have an old result and got a non-404 code.
+            raise self.UpstreamError("%s status on GET %s" % (
+                response.status_code, url))
+
+        # pypi.org provides X-PYPI-LAST-SERIAL header in case of 200 returns.
+        # devpi-master may provide a 200 but not supply the header
+        # (it's really a 404 in disguise and we should change
+        # devpi-server behaviour since pypi.org serves 404
+        # on non-existing projects for a longer time now).
+        # Returning a 200 with "no such project" was originally meant to
+        # provide earlier versions of easy_install/pip to request the full
+        # simple page.
+        try:
+            serial = int(response.headers.get(str("X-PYPI-LAST-SERIAL")))
+        except (TypeError, ValueError):
+            # handle missing or invalid X-PYPI-LAST-SERIAL header
+            serial = -1
+
+        if serial < cache_serial:
+            raise self.UpstreamError(
+                "serial mismatch on GET %s, "
+                "cache_serial %s is newer than returned serial %s" % (
+                    url, cache_serial, serial))
+
+        threadlog.debug("%s: got response with serial %s", project, serial)
+
+        # check returned url has the same normalized name
+        ret_project = response.url.strip("/").split("/")[-1]
+        assert project == normalize_name(ret_project)
+
+        # parse simple index's link
+        assert response.text is not None, response.text
+        releaselinks = parse_index(response.url, response.text).releaselinks
+        num_releaselinks = len(releaselinks)
+        key_hrefs = [None] * num_releaselinks
+        requires_python = [None] * num_releaselinks
+        yanked = [None] * num_releaselinks
+        _key_from_link = partial(
+            key_from_link, self.keyfs, user=self.user.name, index=self.index)
+        for index, releaselink in enumerate(releaselinks):
+            key = _key_from_link(releaselink)
+            href = key.relpath
+            if releaselink.hash_spec:
+                href = f"{href}#{releaselink.hash_spec}"
+            key_hrefs[index] = (releaselink.basename, href)
+            requires_python[index] = releaselink.requires_python
+            yanked[index] = releaselink.yanked
+        return dict(
+            serial=serial,
+            releaselinks=releaselinks,
+            key_hrefs=key_hrefs,
+            requires_python=requires_python,
+            yanked=yanked,
+            devpi_serial=response.headers.get("X-DEVPI-SERIAL"))
+
+    def _update_simplelinks(self, project, info, newlinks):
+        if self.xom.is_replica():
+            # on the replica we wait for the changes to arrive (changes were
+            # triggered by our http request above) because we have no direct
+            # writeaccess to the db other than through the replication thread
+            # and we need the current data of the new entries
+            devpi_serial = int(info["devpi_serial"])
+            threadlog.debug("get_simplelinks pypi: waiting for devpi_serial %r",
+                            devpi_serial)
+            if self.keyfs.wait_tx_serial(devpi_serial, timeout=self.timeout):
+                threadlog.debug("get_simplelinks pypi: finished waiting for devpi_serial %r",
+                                devpi_serial)
+                # XXX raise TransactionRestart to get a consistent clean view
+                self.keyfs.restart_read_transaction()
+                is_expired, links, cache_serial = self._load_cache_links(project)
+            if links is not None:
+                self.cache_retrieve_times.refresh(project)
+                return links
+            raise self.UpstreamError("no cache links from master for %s" %
+                                     project)
+        else:
+            # on the master we need to write the updated links.
+            if not self.keyfs.tx.write:
+                # we are in a read-only transaction so we need to start a
+                # write transaction.
+                self.keyfs.restart_as_write_transaction()
+
+            maplink = partial(
+                self.filestore.maplink,
+                user=self.user.name, index=self.index, project=project)
+            # calling maplink on the links creates the entries in the database
+            for x in info["releaselinks"]:
+                maplink(x)
+            # this stores the simple links info
+            self._save_cache_links(
+                project,
+                info["key_hrefs"], info["requires_python"], info["yanked"],
+                info["serial"])
+            return newlinks
+
     def get_simplelinks_perstage(self, project):
         """ return all releaselinks from the index, returning cached entries
         if we have a recent enough request stored locally.
@@ -429,111 +537,27 @@ class PyPIStage(BaseStage):
             raise self.UpstreamNotFoundError(
                 "cached not found for project %s" % project)
 
-        # get the simple page for the project
-        url = self.mirror_url + project + "/"
-        threadlog.debug("reading index %s", url)
-        response = self.httpget(url, allow_redirects=True, timeout=self.timeout)
-        if response.status_code != 200:
+        try:
+            info = self._fetch_releaselinks(project, cache_serial)
+        except (self.UpstreamNotFoundError, self.UpstreamError) as e:
             # if we have and old result, return it. While this will
             # miss the rare event of actual project deletions it allows
             # to stay resilient against server misconfigurations.
             if links is not None:
                 threadlog.warn(
-                    "serving stale links for %r, url %r responded %s %s",
-                    project, url, response.status_code, response.reason)
+                    "serving stale links, because of exception %s",
+                    lazy_format_exception(e))
                 return links
-            if response.status_code == 404:
-                self.cache_retrieve_times.refresh(project)
-                raise self.UpstreamNotFoundError(
-                    "not found on GET %s" % url)
+            raise
 
-            # we don't have an old result and got a non-404 code.
-            raise self.UpstreamError("%s status on GET %s" % (
-                response.status_code, url))
-
-        # pypi.org provides X-PYPI-LAST-SERIAL header in case of 200 returns.
-        # devpi-master may provide a 200 but not supply the header
-        # (it's really a 404 in disguise and we should change
-        # devpi-server behaviour since pypi.org serves 404
-        # on non-existing projects for a longer time now).
-        # Returning a 200 with "no such project" was originally meant to
-        # provide earlier versions of easy_install/pip to request the full
-        # simple page.
-        try:
-            serial = int(response.headers.get(str("X-PYPI-LAST-SERIAL")))
-        except (TypeError, ValueError):
-            # handle missing or invalid X-PYPI-LAST-SERIAL header
-            serial = -1
-
-        if serial < cache_serial:
-            threadlog.warn("serving cached links for %s "
-                           "because returned serial %s, cache_serial %s is better!",
-                           response.url, serial, cache_serial)
+        newlinks = join_links_data(
+            info["key_hrefs"], info["requires_python"], info["yanked"])
+        if links is not None and set(links) == set(newlinks):
+            # no changes
+            self.cache_retrieve_times.refresh(project)
             return links
 
-        threadlog.debug("%s: got response with serial %s", project, serial)
-
-        # check returned url has the same normalized name
-        ret_project = response.url.strip("/").split("/")[-1]
-        assert project == normalize_name(ret_project)
-
-        # parse simple index's link
-        assert response.text is not None, response.text
-        result = parse_index(response.url, response.text)
-        releaselinks = result.releaselinks
-
-        # first we try to process mirror links without an explicit write transaction.
-        # if all links already exist in storage we might then return our already
-        # cached information about them.  Note that _save_cache_links() will
-        # implicitely update non-persisted cache timestamps.
-        def map_and_dump():
-            # both maplink() and _save_cache_links() will not modify
-            # storage if there are no changes so they operate fine within a
-            # read-transaction if nothing changed.
-            maplink = partial(
-                self.filestore.maplink,
-                user=self.user.name, index=self.index, project=project)
-            entries = [maplink(link) for link in releaselinks]
-            links = [make_key_and_href(entry) for entry in entries]
-            requires_python = [link.requires_python for link in releaselinks]
-            yanked = [link.yanked for link in releaselinks]
-            self._save_cache_links(project, links, requires_python, yanked, serial)
-            return join_links_data(links, requires_python, yanked)
-
-        try:
-            return map_and_dump()
-        except self.keyfs.ReadOnly:
-            pass
-
-        # we know that some links changed in this simple page.
-        # On the master we need to write-update, on the replica
-        # we wait for the changes to arrive (changes were triggered
-        # by our http request above) because have no direct write
-        # access to the db other than through the replication thread.
-        if self.xom.is_replica():
-            # we have already triggered the master above
-            # and now need to wait until the parsed new links are
-            # transferred back to the replica
-            devpi_serial = int(response.headers["X-DEVPI-SERIAL"])
-            threadlog.debug("get_simplelinks pypi: waiting for devpi_serial %r",
-                            devpi_serial)
-            if self.keyfs.wait_tx_serial(devpi_serial, timeout=self.timeout):
-                threadlog.debug("get_simplelinks pypi: finished waiting for devpi_serial %r",
-                                devpi_serial)
-                # XXX raise TransactionRestart to get a consistent clean view
-                self.keyfs.restart_read_transaction()
-                is_expired, links, cache_serial = self._load_cache_links(project)
-            if links is not None:
-                self.cache_retrieve_times.refresh(project)
-                return links
-            raise self.UpstreamError("no cache links from master for %s" %
-                                     project)
-        else:
-            # we are on the master and something changed and we are
-            # in a readonly-transaction so we need to start a write
-            # transaction and perform map_and_dump.
-            self.keyfs.restart_as_write_transaction()
-            return map_and_dump()
+        return self._update_simplelinks(project, info, newlinks)
 
     def has_project_perstage(self, project):
         if self.is_project_cached(project):

--- a/server/news/async_simplelinks.feature
+++ b/server/news/async_simplelinks.feature
@@ -1,0 +1,1 @@
+Use aiohttp (asyncio) for fetching release links from mirrors to return stale links immediately in case of a timeout, but update the database in the background for the next request.

--- a/server/setup.py
+++ b/server/setup.py
@@ -27,6 +27,7 @@ if __name__ == "__main__":
     CHANGELOG = get_changelog()
 
     install_requires = ["py>=1.4.23",
+                        "aiohttp!=4.0.0a0,!=4.0.0a1",
                         "appdirs",
                         "argon2-cffi",
                         "attrs",

--- a/server/test_devpi_server/conftest.py
+++ b/server/test_devpi_server/conftest.py
@@ -276,6 +276,9 @@ def makexom(request, gentmp, httpget, monkeypatch, storage_info):
             xom.thread_pool.start()
         elif request.node.get_closest_marker("with_notifier"):
             xom.thread_pool.start_one(xom.keyfs.notifier)
+        if not request.node.get_closest_marker("start_threads"):
+            # we always need the async_thread
+            xom.thread_pool.start_one(xom.async_thread)
         request.addfinalizer(xom.thread_pool.shutdown)
         return xom
     return makexom

--- a/server/test_devpi_server/conftest.py
+++ b/server/test_devpi_server/conftest.py
@@ -333,6 +333,14 @@ def httpget(pypiurls):
             self._md5 = hashlib.md5()
             self.call_log = []
 
+        async def async_httpget(self, url, allow_redirects, timeout=None, extra_headers=None):
+            response = self.__call__(url, allow_redirects, extra_headers, timeout=timeout)
+            if response.status_code < 300:
+                text = response.text
+            else:
+                text = None
+            return (response, text)
+
         def __call__(self, url, allow_redirects=False, extra_headers=None, **kw):
             class mockresponse:
                 def __init__(xself, url):
@@ -347,6 +355,10 @@ def httpget(pypiurls):
                     xself.allow_redirects = allow_redirects
                     if "content" in fakeresponse:
                         xself.raw = py.io.BytesIO(fakeresponse["content"])
+
+                @property
+                def status(xself):
+                    return xself.status_code
 
                 def __repr__(xself):
                     return "<mockresponse %s url=%s>" % (xself.status_code,

--- a/server/test_devpi_server/test_extpypi.py
+++ b/server/test_devpi_server/test_extpypi.py
@@ -555,6 +555,47 @@ class TestPyPIStageprojects:
         # now the timestamp should differ
         assert projectnames._timestamp > ts
 
+    @pytest.mark.notransaction
+    def test_simplelinks_timeout(self, pypistage):
+        import asyncio
+        # release files should be updated in background in case of timeout
+        pypistage.timeout = 0.1
+        orig_async_httpget = pypistage.async_httpget
+
+        async def sleeping_async_httpget(*args, **kw):
+            await asyncio.sleep(0.2)
+            return await orig_async_httpget(*args, **kw)
+
+        # first we need some releases in the db
+        pypistage.mock_simple("pkg", text='<a href="pkg-1.0.zip"</a>')
+        with pypistage.keyfs.transaction(write=False):
+            assert [
+                (x.project, x.version)
+                for x in pypistage.get_releaselinks("pkg")] == [
+                    ('pkg', '1.0')]
+
+        # now expire the cache, add a version on the mirror and fetch again with a timeout
+        pypistage.cache_retrieve_times.expire("pkg")
+        pypistage.mock_simple("pkg", text='<a href="pkg-1.0.zip"</a><a href="pkg-2.0.zip"</a>')
+        pypistage.async_httpget = sleeping_async_httpget
+        serial = pypistage.keyfs.get_current_serial()
+        # we should get stale results
+        with pypistage.keyfs.transaction(write=False):
+            assert pypistage.cache_retrieve_times.is_expired("pkg", pypistage.cache_expiry)
+            assert [
+                (x.project, x.version)
+                for x in pypistage.get_releaselinks("pkg")] == [
+                    ('pkg', '1.0')]
+        # now we wait for the new serial to arrive
+        pypistage.keyfs.wait_tx_serial(serial + 1)
+        # and we should see the new version
+        with pypistage.keyfs.transaction(write=False):
+            assert not pypistage.cache_retrieve_times.is_expired("pkg", pypistage.cache_expiry)
+            assert sorted([
+                (x.project, x.version)
+                for x in pypistage.get_releaselinks("pkg")]) == sorted([
+                    ('pkg', '1.0'), ('pkg', '2.0')])
+
 
 def raise_ValueError():
     raise ValueError(42)

--- a/server/test_devpi_server/test_extpypi.py
+++ b/server/test_devpi_server/test_extpypi.py
@@ -344,8 +344,8 @@ class TestExtPYPIDB:
         ret = pypistage.get_releaselinks("pytest")
         assert len(ret) == 1
         pypistage.mock_simple("pytest", text="", pypiserial=9)
-        assert len(pypistage.get_releaselinks("pytest")) == 1
-        recs = caplog.getrecords(".*serving cached links.*")
+        (link,) = pypistage.get_releaselinks("pytest")
+        recs = caplog.getrecords(".*serving stale links.*")
         assert len(recs) >= 1
 
     def test_get_releaselinks_cache_no_fresh_write(self, pypistage):

--- a/server/test_devpi_server/test_main.py
+++ b/server/test_devpi_server/test_main.py
@@ -98,11 +98,13 @@ def test_pyramid_configure_called(makexom):
 def test_requests_only(makexom):
     xom = makexom(opts=["--requests-only"])
     xom.create_app()
-    assert not xom.thread_pool._objects
+    assert len(xom.thread_pool._objects) == 1
+    assert hasattr(xom.thread_pool._objects[0], "loop")
 
     xom = makexom(opts=["--requests-only", "--master=http://localhost:3140"])
     xom.create_app()
-    assert not xom.thread_pool._objects
+    assert len(xom.thread_pool._objects) == 1
+    assert hasattr(xom.thread_pool._objects[0], "loop")
 
 
 @wsgi_run_throws

--- a/server/test_devpi_server/test_views.py
+++ b/server/test_devpi_server/test_views.py
@@ -1578,13 +1578,13 @@ def test_delete_mirror(mapp, simpypi, testapp, xom):
         key = testapp.xom.filestore.get_key_from_relpath(path.strip("/"))
         assert not key.exists()
 
-    # patch httpget to simulate broken PyPI
-    def httpget(url, **kwargs):
+    # patch async_httpget to simulate broken PyPI
+    async def async_httpget(url, **kwargs):
         class Response:
-            status_code = 503
+            status = 503
             reason = "Service Unavailable"
-        return Response()
-    xom.httpget = httpget
+        return (Response(), None)
+    xom.async_httpget = async_httpget
 
     # to prove that all metadata is gone when deleting the stage,
     # we recreate the stage, block access to PyPI


### PR DESCRIPTION
Use aiohttp (asyncio) for fetching release links from mirrors to return stale links immediately in case of a timeout, but update the database in the background for the next request. 