### PR TITLE
Update launchd-macos.txt.template

### DIFF
--- a/server/devpi_server/cfg/launchd-macos.txt.template
+++ b/server/devpi_server/cfg/launchd-macos.txt.template
@@ -2,15 +2,14 @@ On macOS you can let devpi-server be run at startup via launchctl.
 
 Place the example net.devpi.plist file in ~/Library/LaunchAgents/
 
-Then use the following commands to initialize the service and start devpi-server:
+Then use the following command to initialize and start the service:
 
-  launchctl load -w ~/Library/LaunchAgents/devpi-server.plist
-  launchctl start net.devpi.devpi-server
+  launchctl load -w ~/Library/LaunchAgents/net.devpi.plist
 
 To stop devpi-server, use the following command:
 
-  launchctl stop net.devpi.devpi-server
+  launchctl stop net.devpi
 
 To prevent the service from being run at startup use:
 
-  launchctl unload ~/Library/LaunchAgents/devpi-server.plist
+  launchctl unload ~/Library/LaunchAgents/net.devpi.plist


### PR DESCRIPTION
Updated the template text to match the net.devpi.plist file generated by server/devpi_server/genconfig.py.

Removed the “start” invocation, because RunAtLoad is used in the generated config file.