### PR TITLE
Avoid accessing PyPI for projects that don't exist

### DIFF
--- a/server/news/check-locally-for-pypi-packages.bugfix
+++ b/server/news/check-locally-for-pypi-packages.bugfix
@@ -1,0 +1,1 @@
+Don't access PyPI for projects that aren't present in the local PyPI index. This improves response times and avoids leaking typos of private package names upstream.

--- a/server/test_devpi_server/conftest.py
+++ b/server/test_devpi_server/conftest.py
@@ -351,6 +351,7 @@ def httpget(pypiurls):
                         fakeresponse = dict(
                             status_code=404,
                             reason="Not Found")
+                    assert "assert_unloaded" not in fakeresponse, "Attempted to load URL '%s'" % url
                     fakeresponse["headers"] = requests.structures.CaseInsensitiveDict(
                         fakeresponse.setdefault("headers", {}))
                     xself.__dict__.update(fakeresponse)
@@ -393,6 +394,9 @@ def httpget(pypiurls):
                 "Devpi Mock Error"))
             log.debug("set mocking response %s %s", mockurl, kw)
             self.url2response[mockurl] = kw
+
+        def assert_unloaded(self, url):
+            self.url2response[url] = {"assert_unloaded": True}
 
         def mock_simple(self, name, text="", pkgver=None, hash_type=None,
                         pypiserial=10000, remoteurl=None, requires_python=None,


### PR DESCRIPTION
Previously, when a project without any cached links was requested from the `PyPIStage`, it would immediately try to load that package from the upstream server. This change introduces a check to make sure the package is actually in the stage before trying to load it.

This improves response times on slow connections, reduces the load on the upstream server, and avoids leaking potential typos of private package names to the upstream server.