### PR TITLE
docs: Fix a few typos

### DIFF
--- a/client/devpi/upload.py
+++ b/client/devpi/upload.py
@@ -538,7 +538,7 @@ class Exported:
 sdistformat2option = {
     "tgz": "gztar",  # gzipped tar-file
     "tar": "tar",    # un-compressed tar
-    "zip": "zip",    # comparessed zip file
+    "zip": "zip",    # compressed zip file
     "tz": "ztar",    # compressed tar file
     "tbz": "bztar",  # bzip2'ed tar-file
 }

--- a/server/devpi_server/keyfs.py
+++ b/server/devpi_server/keyfs.py
@@ -1,6 +1,6 @@
 """
 filesystem key/value storage with support for storing and retrieving
-basic python types based on parametrizable keys.  Multiple
+basic python types based on parameterizable keys.  Multiple
 read Transactions can execute concurrently while at most one
 write Transaction is ongoing.  Each Transaction will see a consistent
 view of key/values referring to the point in time it was started,


### PR DESCRIPTION
There are small typos in:
- client/devpi/upload.py
- server/devpi_server/keyfs.py

Fixes:
- Should read `parameterizable` rather than `parametrizable`.
- Should read `compressed` rather than `comparessed`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md