### PR TITLE
Build sphinx docs from separate directories

### DIFF
--- a/client/devpi/upload.py
+++ b/client/devpi/upload.py
@@ -504,11 +504,17 @@ class Exported:
 
     def setup_build_docs(self):
         name, version = self.setup_name_and_version()
-        for guess in ("doc", "docs"):
-            docs = self.rootpath.join(guess)
-            if docs.join("conf.py").exists():
-                break
         build = self.rootpath.join("build")
+        for guess in ("doc", "docs", "source"):
+            docs = self.rootpath.join(guess)
+            if docs.isdir():
+                if docs.join("conf.py").exists():
+                    break
+                else:
+                    source = docs.join("source")
+                    if source.isdir() and source.join("conf.py").exists():
+                        build, docs = docs.join("build"), source
+                        break
         cmd = ["sphinx-build", "-E", docs, build]
         if self.args.verbose:
             ret = self.hub.popen_check(cmd, cwd=self.rootpath)

--- a/client/news/build-docs-with-separate-build-and-source-directories.bugfix
+++ b/client/news/build-docs-with-separate-build-and-source-directories.bugfix
@@ -1,0 +1,1 @@
+Restore ability to build docs if project uses separate build and source directories for documentation.

--- a/client/testing/test_upload.py
+++ b/client/testing/test_upload.py
@@ -678,3 +678,19 @@ def test_filter_latest():
     filtered = d[path]
     assert filtered.name == 'test-abc'
     assert filtered.version == u'0.10'
+
+
+@pytest.mark.parametrize("structure", [
+    {"doc": {"conf.py": "", "index.rst": ""}},
+    {"docs": {"conf.py": "", "index.rst": ""}},
+    {"doc": {"source": {"conf.py": "", "index.rst": ""}}},
+    {"docs": {"source": {"conf.py": "", "index.rst": ""}}},
+    {"source": {"conf.py": "", "index.rst": ""}},
+])
+def test_build_docs(initproj, out_devpi, structure):
+    proj = initproj("hello1.1", structure)
+    out = out_devpi("upload", "--no-isolation", "--dry-run", "--only-docs")
+    assert out.ret == 0
+
+    docs = proj.join("dist/hello1.1-0.1.doc.zip")
+    assert docs.isfile()


### PR DESCRIPTION
When you create documentation with Sphinx, it gives you the option to split the documentation into
separate source and output directories.

    $ sphinx-quickstart docs
    Welcome to the Sphinx 5.0.2 quickstart utility.
    
    Please enter values for the following settings (just press Enter to
    accept a default value, if one is given in brackets).
    
    Selected root path: docs
    
    You have two options for placing the build directory for Sphinx output.
    Either, you use a directory "_build" within the root path, or you separate
    "source" and "build" directories within the root path.
    > Separate source and build directories (y/n) [n]: y
    
    The project name will occur in several places in the built documentation.
    > Project name: Example
    > Author name(s): Rohan B. Dalton
    > Project release []:
    
    If the documents are to be written in a language other than English,
    you can select a language here by its language code. Sphinx will then
    translate text that it generates into that language.
    
    For a list of supported codes, see
    https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language.
    > Project language [en]:
    
    Creating file /Users/rohan/src/external/example/docs/source/conf.py.
    Creating file /Users/rohan/src/external/example/docs/source/index.rst.
    Creating file /Users/rohan/src/external/example/docs/Makefile.
    Creating file /Users/rohan/src/external/example/docs/make.bat.
    
    Finished: An initial directory structure has been created.
    
    You should now populate your master file /Users/rohan/src/external/example/docs/source/index.rst and create other documentation
    source files. Use the Makefile to build the docs, like so:
       make builder
    where "builder" is one of the supported builders, e.g. html, latex or linkcheck.
    
    $ tree
    .
    └── docs
        ├── Makefile
        ├── build
        ├── make.bat
        └── source
            ├── _static
            ├── _templates
            ├── conf.py
            └── index.rst
    
    5 directories, 4 files
    $ pushd docs && make html && popd
    ~/src/external/example/docs ~/src/external/example
    Running Sphinx v5.0.2
    making output directory... done
    building [mo]: targets for 0 po files that are out of date
    building [html]: targets for 1 source files that are out of date
    updating environment: [new config] 1 added, 0 changed, 0 removed
    reading sources... [100%] index
    looking for now-outdated files... none found
    pickling environment... done
    checking consistency... done
    preparing documents... done
    writing output... [100%] index
    generating indices... genindex done
    writing additional pages... search done
    copying static files... done
    copying extra files... done
    dumping search index in English (code: en)... done
    dumping object inventory... done
    build succeeded.
    
    The HTML pages are in build/html.
    ~/src/external/example
    $ tree
    .
    └── docs
        ├── Makefile
        ├── build
        │   ├── doctrees
        │   │   ├── environment.pickle
        │   │   └── index.doctree
        │   └── html
        │       ├── _sources
        │       │   └── index.rst.txt
        │       ├── _static
        │       │   ├── _sphinx_javascript_frameworks_compat.js
        │       │   ├── alabaster.css
        │       │   ├── basic.css
        │       │   ├── custom.css
        │       │   ├── doctools.js
        │       │   ├── documentation_options.js
        │       │   ├── file.png
        │       │   ├── jquery-3.6.0.js
        │       │   ├── jquery.js
        │       │   ├── language_data.js
        │       │   ├── minus.png
        │       │   ├── plus.png
        │       │   ├── pygments.css
        │       │   ├── searchtools.js
        │       │   ├── underscore-1.13.1.js
        │       │   └── underscore.js
        │       ├── genindex.html
        │       ├── index.html
        │       ├── objects.inv
        │       ├── search.html
        │       └── searchindex.js
        ├── make.bat
        └── source
            ├── _static
            ├── _templates
            ├── conf.py
            └── index.rst

Previously this wasn't a problem, because if you run 

    $ python setup.py build_sphinx -E ./docs ./build
   
Sphinx will detect the source directory inside `./docs`.
But running 

    $ sphinx-build -E docs ./build

produces an error


    Running Sphinx v4.4.0
   
    Configuration error:
    config directory doesn't contain a conf.py file

So now if you have separate source and build directories for your documentation, the documentation
will no longer build in devpi. 


I've made a small change that tests if there's a `source` directory that contains a `conf.py`
file inside each of the previous guesses. 
And additionally if there's a project level `source` directory. 