### PR TITLE
Add version constraint <=21.3 to dependency packaging

### DIFF
--- a/server/setup.py
+++ b/server/setup.py
@@ -42,6 +42,7 @@ if __name__ == "__main__":
                         'ruamel.yaml',
                         "strictyaml",
                         "lazy",
+                        "packaging<=21.3",
                         ]
     extras_require = {}
 


### PR DESCRIPTION
Release 22.0 of `packaging` was published on december 8 and it breaks `devpi` for many packages (`pytz` being one of them).