### PR TITLE
Properly set PATH_INFO when X-outside-url header with path is used

### DIFF
--- a/server/devpi_server/middleware.py
+++ b/server/devpi_server/middleware.py
@@ -18,4 +18,6 @@ class OutsideURLMiddleware(object):
             environ['HTTP_HOST'] = outside_url.netloc
             if outside_url.path:
                 environ['SCRIPT_NAME'] = outside_url.path
+                if environ['PATH_INFO'].startswith(outside_url.path):
+                    environ['PATH_INFO'] = environ['PATH_INFO'][len(outside_url.path):]
         return self.app(environ, start_response)


### PR DESCRIPTION
When the `X-outside-url` header is passed in a request to devpi-server, the path portion is set as the wsgi `SCRIPT_NAME` variable so it can run in a subpath. However, the wsgi spec [1] states that `SCRIPT_NAME` and `PATH_INFO` together constitute the complete URL but `PATH_INFO` isn't modified. This commit adds stripping of the `SCRIPT_NAME` from the beginning of `PATH_INFO`.

[1] https://wsgi.readthedocs.io/en/latest/definitions.html#standard-environ-keys

---

For reference, here are two minimal configs for traefik and nginx to to serve devpi on the sub path `/devpi`

**nginx.conf**
```
server {
    location /devpi {
        proxy_set_header X-outside-url $scheme://$http_host/devpi;
        proxy_pass http://localhost:3141;
    }
}
```

**traefik labels** (for running in docker-compose)
```
labels:
  - "traefik.enable=true"
  - "traefik.http.routers.devpi.rule=PathPrefix(`/devpi`)"
  - "traefik.http.routers.devpi.middlewares=devpi-outside-url"
  - "traefik.http.middlewares.devpi-outside-url.headers.customrequestheaders.X-outside-url=http://localhost/devpi"
```