### PR TITLE
Replace deprecated BadZipfile with BadZipFile

### DIFF
--- a/common/devpi_common/archive.py
+++ b/common/devpi_common/archive.py
@@ -32,7 +32,7 @@ def Archive(path_or_file):
     try:
         try:
             return ZipArchive(f)
-        except zipfile.BadZipfile:
+        except zipfile.BadZipFile:
             f.seek(0)
             try:
                 return TarArchive(f)


### PR DESCRIPTION
`BadZipfile` (with a small `f`) has been deprecated since Python 3.2, use `BadZipFile` (big `F`) instead, added in 3.2.

* https://docs.python.org/3/library/zipfile.html#zipfile.BadZipfile
* https://github.com/python/cpython/issues/86437