### PR TITLE
Add more docs for changing mirror whitelists

### DIFF
--- a/doc/userman/devpi_indices.rst
+++ b/doc/userman/devpi_indices.rst
@@ -439,6 +439,10 @@ You can also whitelist all packages on an index by setting mirror_whitelist to a
      acl_toxresult_upload=:ANONYMOUS:
      mirror_whitelist=*
      mirror_whitelist_inheritance=intersection
+     
+If you've modifyied the mirror whitelist to add a package you might need to run 
+`devpi refresh mypkg` to make the package versions from pypi visible. Multiple 
+packages can be added by comma separating them. 
 
 .. _index_description:
 


### PR DESCRIPTION
At least to me it wasn't obvious that I needed to refresh the package to get the versions for pypi to work. Also I couldn't see it documented anywhere  that these take a comma separated list, which it seems to.