### PR TITLE
client: Use build instead of pep517

### DIFF
--- a/client/devpi/upload.py
+++ b/client/devpi/upload.py
@@ -5,8 +5,8 @@ import py
 import re
 import zipfile
 
+import build.util
 import check_manifest
-import pep517.meta
 
 from devpi_common.metadata import Version, get_pyversion_filetype
 from devpi_common.archive import Archive
@@ -378,9 +378,11 @@ class Exported:
         return "<Exported %s>" % self.rootpath
 
     def setup_name_and_version(self):
-        result = pep517.meta.load(self.rootpath.strpath)
-        name = result.metadata["name"]
-        version = result.metadata["version"]
+        metadata = build.util.project_wheel_metadata(
+            self.rootpath.strpath, False
+        )
+        name = metadata["name"]
+        version = metadata["version"]
         self.hub.debug("name, version = %s, %s" % (name, version))
         return name, version
 

--- a/client/setup.py
+++ b/client/setup.py
@@ -31,7 +31,6 @@ if __name__ == "__main__":
         "check-manifest>=0.28",
         "devpi_common<4,>=3.6.0",
         "iniconfig",
-        "pep517",
         "pkginfo>=1.4.2",
         "platformdirs",
         "pluggy>=0.6.0,<2.0",


### PR DESCRIPTION
pep517 has been renamed to pyproject-hooks, and as a consequence all of the deprecated functionality has been removed. Users of that functionality should switch to using build. Switch to using a method under build.util to determine the wheel metadata for upload.