### PR TITLE
Handle 403, 404 gracefully without system exit

### DIFF
--- a/client/devpi/main.py
+++ b/client/devpi/main.py
@@ -333,7 +333,13 @@ class Hub:
                 else:
                     self.warn(
                         "You don't have permission to access this index.")
-            raise SystemExit(1)
+            elif reply.status_code == 404:
+                self.warn("Connected index does not exist.")
+            else:
+                self.fatal("Unhandled status code %s %s%s" % (
+                reply.status_code, reply.reason,
+                reply.get_error_message(self.args.debug))
+                          )
 
     @property
     def venv(self):

--- a/client/news/1011.bugfix
+++ b/client/news/1011.bugfix
@@ -1,0 +1,1 @@
+change HTTP status codes >=400 to use self.fatal instead of raw SystemExit, protect 403 and 404 errors from SystemExit


### PR DESCRIPTION
Reduces 403 and 404 to just warnings, and uses self.fatal for all other status codes instead of calling a raw `SystemExit(1)`

Connected to Issue #1011 