### PR TITLE
Add `upload-time` support to links parsed from a JSON API

### DIFF
--- a/server/devpi_server/importexport.py
+++ b/server/devpi_server/importexport.py
@@ -561,12 +561,14 @@ class Importer:
                 links = [(url.basename, entry.relpath)]
                 requires_python = [versions[version].get('requires_python')]
                 yanked = [versions[version].get('yanked')]
-                for key, href, require_python, is_yanked in links_with_data:
+                upload_time = [versions[version].get('upload_time')]
+                for key, href, require_python, is_yanked, upload_time_ in links_with_data:
                     links.append((key, href))
                     requires_python.append(require_python)
                     yanked.append(is_yanked)
+                    upload_time.append(upload_time_)
                 stage._save_cache_links(
-                    project, links, requires_python, yanked, serial, None)
+                    project, links, requires_python, yanked, upload_time, serial, None)
             # devpi-server-2.1 exported with md5 checksums
             if "md5" in mapping:
                 assert "hash_spec" not in mapping

--- a/server/devpi_server/model.py
+++ b/server/devpi_server/model.py
@@ -37,13 +37,13 @@ class _Unknown:
 Unknown = _Unknown()
 
 
-def join_links_data(links, requires_python, yanked):
-    # build list of (key, href, require_python, yanked) tuples
+def join_links_data(links, requires_python, yanked, upload_time):
+    # build list of (key, href, require_python, yanked, upload_time) tuples
     result = []
-    links = zip_longest(links, requires_python, yanked, fillvalue=None)
-    for link, require_python, yanked in links:
+    links = zip_longest(links, requires_python, yanked, upload_time, fillvalue=None)
+    for link, require_python, yanked, upload_time in links:
         key, href = link
-        result.append((key, href, require_python, yanked))
+        result.append((key, href, require_python, yanked, upload_time))
     return result
 
 
@@ -1348,9 +1348,10 @@ class PrivateStage(BaseStage):
         data = self.key_projsimplelinks(project).get()
         links = data.get("links", [])
         requires_python = data.get("requires_python", [])
+        upload_time = data.get("upload_time", [])
         yanked = []  # PEP 592 isn't supported for private stages yet
         return self.SimpleLinks(
-            join_links_data(links, requires_python, yanked))
+            join_links_data(links, requires_python, yanked, upload_time))
 
     def _regen_simplelinks(self, project_input):
         project = normalize_name(project_input)
@@ -1711,7 +1712,7 @@ class SimplelinkMeta:
     __slots__ = (
         '__basename', '__cmpval', '__ext', '__hash_spec',
         '__name', '__path', '__url', '__version',
-        'key', 'href', 'require_python', 'yanked')
+        'key', 'href', 'require_python', 'yanked', "upload_time")
 
     def __init__(self, link_info):
         self.__basename = notset
@@ -1722,7 +1723,7 @@ class SimplelinkMeta:
         self.__path = notset
         self.__url = notset
         self.__version = notset
-        (self.key, self.href, self.require_python, self.yanked) = link_info
+        (self.key, self.href, self.require_python, self.yanked, self.upload_time) = link_info
 
     def __eq__(self, other):
         if isinstance(other, type(self)):
@@ -1748,6 +1749,8 @@ class SimplelinkMeta:
             return self.require_python
         elif index == 3:
             return self.yanked
+        elif index == 4:
+            return self.upload_time
         raise IndexError(f"{self.__class__.__name__} index out of range")
 
     def __splitbasename(self):
@@ -1812,7 +1815,8 @@ class SimplelinkMeta:
             f"key={self.key!r} "
             f"href={self.href!r} "
             f"require_python={self.require_python!r} "
-            f"yanked={self.yanked!r}>")
+            f"yanked={self.yanked!r} "
+            f"upload_time={self.upload_time!r}>>")
 
 
 def make_key_and_href(entry):

--- a/server/devpi_server/views.py
+++ b/server/devpi_server/views.py
@@ -692,6 +692,8 @@ class PyPIView:
                 data["requires-python"] = link.require_python
             if link.yanked is not None and link.yanked is not False:
                 data["yanked"] = link.yanked
+            if link.upload_time is not None:
+                data["upload-time"] = link.upload_time
             info = json.dumps(data, indent=None, sort_keys=False)
             if first:
                 yield f'{info}'.encode("utf-8")

--- a/server/test_devpi_server/test_importexport.py
+++ b/server/test_devpi_server/test_importexport.py
@@ -473,12 +473,12 @@ class TestImportExport:
             projects = stage.list_projects_perstage()
             assert projects == {'package': 'package'}
             links = sorted(
-                (x.key, x.href, x.require_python, x.yanked)
+                (x.key, x.href, x.require_python, x.yanked, x.upload_time)
                 for x in stage.get_simplelinks_perstage("package"))
             assert links == [
-                ('package-1.1.zip', 'root/pypi/+f/a66/5a45920422f9d/package-1.1.zip', None, None),
-                ('package-1.2.zip', 'root/pypi/+f/b3a/8e0e1f9ab1bfe/package-1.2.zip', None, ""),
-                ('package-2.0.zip', 'root/pypi/+f/35a/9e381b1a27567/package-2.0.zip', '>=3.5', None)]
+                ('package-1.1.zip', 'root/pypi/+f/a66/5a45920422f9d/package-1.1.zip', None, None, None),
+                ('package-1.2.zip', 'root/pypi/+f/b3a/8e0e1f9ab1bfe/package-1.2.zip', None, "", None),
+                ('package-2.0.zip', 'root/pypi/+f/35a/9e381b1a27567/package-2.0.zip', '>=3.5', None, None)]
 
     def test_mirrordata(self, caplog, impexp):
         mapp = impexp.import_testdata('mirrordata')

--- a/server/test_devpi_server/test_mirror.py
+++ b/server/test_devpi_server/test_mirror.py
@@ -1011,7 +1011,7 @@ async def test_get_simplelinks_perstage_when_http_error(exc, pypistage, monkeypa
     from devpi_server.model import SimpleLinks
 
     # to reach the code path in question, we must have cached links
-    links = [("key", "href", "req_py", "yanked")]
+    links = [("key", "href", "req_py", "yanked", "upload_time")]
 
     def mock_load_cache_links(project):
         return (True, links, 42)

--- a/web/news/1023.feature
+++ b/web/news/1023.feature
@@ -1,0 +1,1 @@
+Add support for mirrored file `upload-time` in the simple JSON API


### PR DESCRIPTION
Adds support for including the `upload-time` field from PyPI in the JSON output. This allows package managers to filter files by upload time.

For example:

```
❯ curl -s -H 'Accept: application/vnd.pypi.simple.v1+json' 'http://localhost:3141/root/pypi/+simple/black' | jq .files\[0]
{
  "filename": "black-18.3a0-py3-none-any.whl",
  "url": "http://localhost:3141/root/pypi/+f/718/3263650ba3071/black-18.3a0-py3-none-any.whl",
  "hashes": {
    "sha256": "7183263650ba3071034e90b40a1ea74abccbd32cf525cef6d7914479dbe7f2fb"
  },
  "requires-python": ">=3.6",
  "upload-time": "2018-03-14T21:30:34.781336Z"
}
```

I'd appreciate some guidance on where to add test coverage.