### PR TITLE
Fix #983: plugin hook to provide auth for mirrors

### DIFF
--- a/server/devpi_server/hookspecs.py
+++ b/server/devpi_server/hookspecs.py
@@ -201,6 +201,18 @@ def devpiserver_auth_denials(request, acl, user, stage):
 
 
 @hookspec
+def devpiserver_get_mirror_auth(mirror_url, www_authenticate_header):
+    """Provide an http "Authorization" header to access a mirror.
+
+    Return a string which will be set as the authorization header for all http
+    requests to this mirror.
+
+    Return None or an empty string if no credentials can be determined for the
+    supplied url.
+    """
+
+
+@hookspec
 def devpiserver_get_stage_customizer_classes():
     """EXPERIMENTAL!
 


### PR DESCRIPTION
This is a replacement for my original PR #984 based on suggestions from @fschulze. As their suggestions resulted in a complete rewrite, and there were also a large number of commits from the primary repo to merge in to my fork in the meantime, it seemed easier to me to branch off the latest `main` and submit a new PR.

In essence, this PR adds a new plugin hook for devpi_server called `devpiserver_get_mirror_auth()` which can be used to provide an "Authorization" header to be submitted with requests to mirrors (such as private, secured, package indexes). The hook gets called when devpi receives a 401 or 403 from an upstream index and any generated credentials are tried sequentially until one works. That credential will then be used for all future requests to the index - if it stops working, any remaining credentials are tried, then the response is propagated up the chain. Any future requests will then cause the hook to be called again, potentially obtaining fresh credentials.

For reference, I am currently using this with a very simple keyring based hook implementation that looks like this:
```
@hookimpl()
@suppress(keyring.errors.KeyringError)
def devpiserver_get_mirror_auth(mirror_url, www_authenticate_header):
    cred = keyring.get_credential(mirror_url.hostname, mirror_url.username)
    if cred:
        auth = f"{cred.username or ''}:{cred.password or ''}".encode()
        return f"Basic {b64encode(auth).decode()}"
    return None
```
This provides Basic auth to connect to a secured PyPIServer instance.

If you can give me some advice on the kinds of tests that would be appropriate in this case then I will implement those too.