### PR TITLE
Fix check for extracted path when testing packages where the package …

### DIFF
--- a/client/devpi/test.py
+++ b/client/devpi/test.py
@@ -178,6 +178,11 @@ class UnpackedPackage:
                 # for example the source releases of argon2_cffi
                 inpkgdir = self.rootdir.joinpath(
                     f"{pkgname.replace('-', '_')}-{version}")
+                if not inpkgdir.exists():
+                    # setuptools implementation of PEP625
+                    # replaces dots by underscores
+                    inpkgdir = self.rootdir.joinpath(
+                        f"{pkgname.replace('.', '_')}-{version}")
         if not inpkgdir.exists():
             self.hub.fatal("Couldn't find unpacked package in", inpkgdir)
         self.path_unpacked = inpkgdir

--- a/client/news/pkg_folder.bugfix
+++ b/client/news/pkg_folder.bugfix
@@ -1,0 +1,1 @@
+Fix check for extracted path when testing packages where the package name contains a dot, but the extracted path has underscores.


### PR DESCRIPTION
…name contains a dot, but the extracted path has underscores.

Noticed this happening with latest `setuptools` release with changes for PE625, it causes `devpi test` to fail with an error saying it could not find unpacked package, this PR adds a check for this case. 