### PR TITLE
Add support for UV pip

### DIFF
--- a/server/CHANGELOG
+++ b/server/CHANGELOG
@@ -12,6 +12,7 @@ Features
 
 - Added ``devpiserver_on_toxresult_upload_forbidden`` hook to allow returning a custom message and result (403 or 200).
 
+- Added support uv pip as an installer
 
 
 Bug Fixes

--- a/server/devpi_server/views.py
+++ b/server/devpi_server/views.py
@@ -68,7 +68,7 @@ meta_headers = {
     "X-DEVPI-SERVER-VERSION": server_version}
 
 
-INSTALLER_USER_AGENT = r"([^ ]* )*(distribute|setuptools|pip|pex)/.*"
+INSTALLER_USER_AGENT = r"([^ ]* )*(distribute|setuptools|pip|pex|uv)/.*"
 INSTALLER_USER_AGENT_REGEXP = re.compile(INSTALLER_USER_AGENT)
 
 


### PR DESCRIPTION
This PR add uv pip useragent to the list of supported installer. This makes it easier to use devpi with uv pip