### PR TITLE
Fixing bug in export to temp directory on folders.

### DIFF
--- a/client/devpi/upload.py
+++ b/client/devpi/upload.py
@@ -350,6 +350,8 @@ class Checkout:
         for fn in files:
             source = self.rootpath / fn
             dest = newrepo / fn
+            if os.path.isdir(source):
+                continue
             dest.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(source, dest, follow_symlinks=False)
         self.hub.debug("copied", len(files), "files to", newrepo)

--- a/client/devpi/upload.py
+++ b/client/devpi/upload.py
@@ -350,7 +350,8 @@ class Checkout:
         for fn in files:
             source = self.rootpath / fn
             dest = newrepo / fn
-            if os.path.isdir(source):
+            if source.is_dir() and not source.is_symlink():
+                dest.mkdir(parents=True, exist_ok=True)
                 continue
             dest.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(source, dest, follow_symlinks=False)

--- a/client/news/1057.bugfix
+++ b/client/news/1057.bugfix
@@ -1,0 +1,1 @@
+Fix #1057: PermissionError during upload due to trying to copy a folder like a file.


### PR DESCRIPTION
shtuil.copy2 will throw PermissionError when the destination is a folder. Seeing as we always make parent directories before running copy, there's no point in processing any directories.

Fixes #1057 