### PR TITLE
Added link to download documentation in index, project and version view

### DIFF
--- a/server/test_devpi_server/plugin.py
+++ b/server/test_devpi_server/plugin.py
@@ -910,6 +910,13 @@ class Mapp(MappMixin):
         assert r.status_code == code
         if waithooks:
             self._wait_for_serial_in_result(r)
+
+        # return the file url so users/callers can easily use it
+        # (probably the official server response should include the url)
+        r.file_url = make_file_url(basename, content, stagename=indexname)
+        r.file_url_no_hash = make_file_url(
+            basename, content, stagename=indexname, add_hash=False)
+
         return r
 
     def upload_toxresult(self, path, content, code=200, waithooks=False):

--- a/web/devpi_web/templates/index.pt
+++ b/web/devpi_web/templates/index.pt
@@ -40,7 +40,10 @@
                         </tal:file>
                     </tal:files>
                 </td>
-                <td><a tal:condition="package.docs" href="${package.docs.url}">${package.docs.title}</a></td>
+                <td>
+                    <a tal:condition="package.docs" href="${package.docs.url}">${package.docs.title}</a>
+                    <span tal:condition="package.docs">(<a href="${package.docs.zip_url}">Download</a>)</span>
+                </td>
             </tr>
             </tbody>
         </table>

--- a/web/devpi_web/templates/project.pt
+++ b/web/devpi_web/templates/project.pt
@@ -35,7 +35,10 @@
                 <tr tal:repeat="version versions">
                     <td><a href="${version.index_url}">${version.index_title}</a></td>
                     <td><a href="${version.url}">${version.title}</a></td>
-                    <td><a tal:condition="version.docs" href="${version.docs.url}">${version.docs.title}</a></td>
+                    <td>
+                        <a tal:condition="version.docs" href="${version.docs.url}">${version.docs.title}</a>
+                        <span tal:condition="version.docs">(<a href="${version.docs.zip_url}">Download</a>)</span>
+                    </td>
                 </tr>
             </tbody>
         </table>

--- a/web/devpi_web/templates/version.pt
+++ b/web/devpi_web/templates/version.pt
@@ -98,6 +98,10 @@
             </tbody>
         </table>
 
+        <p tal:condition="docs">
+            Download documentation as zip-file: <a href="${docs.zip_url}">${docs.title}</a>
+        </p>
+
         <div id="description" tal:content="structure content" />
         </div>
         <metal:footer use-macro="request.macros['footer']" />

--- a/web/devpi_web/views.py
+++ b/web/devpi_web/views.py
@@ -781,9 +781,6 @@ def version_get(context, request):
         nav_links.append(dict(
             title="Documentation",
             url=docs['url']))
-        nav_links.append(dict(
-            title="Documentation (Download)",
-            url=docs['zip_url']))
     if home_page:
         nav_links.append(dict(
             title="Homepage",
@@ -834,7 +831,8 @@ def version_get(context, request):
         make_toxresult_url=functools.partial(
             request.route_url, "toxresult",
             user=context.username, index=context.index,
-            project=context.project, version=version))
+            project=context.project, version=version),
+        docs=docs)
 
 
 @view_config(

--- a/web/devpi_web/views.py
+++ b/web/devpi_web/views.py
@@ -474,7 +474,8 @@ def get_docs_info(request, stage, linkstore):
             title="%s-%s" % (name, ver),
             url=request.route_url(
                 "docviewroot", user=stage.user.name, index=stage.index,
-                project=name, version=ver, relpath="index.html"))
+                project=name, version=ver, relpath="index.html"),
+            zip_url=url_for_entrypath(request, links[0].entrypath))
 
 
 def get_user_info(context, request, user):
@@ -780,6 +781,9 @@ def version_get(context, request):
         nav_links.append(dict(
             title="Documentation",
             url=docs['url']))
+        nav_links.append(dict(
+            title="Documentation (Download)",
+            url=docs['zip_url']))
     if home_page:
         nav_links.append(dict(
             title="Homepage",

--- a/web/news/doc_download.feature
+++ b/web/news/doc_download.feature
@@ -1,0 +1,1 @@
+Added a link to download the documentation as zip-file to the index, project and version view.


### PR DESCRIPTION
As discussed in https://github.com/devpi/devpi/issues/1062, added a link to download the zipped documentation to the views.

**Index View:**
![2024-10-09_11h27_47](https://github.com/user-attachments/assets/8e65cfc4-624f-4d2a-975e-095bfa3632fa)

**Project View:**
![2024-10-09_11h35_52](https://github.com/user-attachments/assets/eea12eed-19c5-4bb8-98c6-3bf6f8c4472c)

**Version View:**
![2024-10-09_11h35_41](https://github.com/user-attachments/assets/724b27eb-722d-497e-8200-8e4f59aeb048)

I'm not yet satisfied with the display in the version view and I'm open to feedback.