### PR TITLE
Add a server option to pass a custom connection limit to waitress

### DIFF
--- a/server/devpi_server/config.py
+++ b/server/devpi_server/config.py
@@ -156,6 +156,11 @@ def add_web_options(parser, pluginmanager):
         help="number of threads to start for serving clients.")
 
     parser.addoption(
+        "--connection-limit", type=int,
+        default=100,
+        help="maximum number of simultaneous client connections.")
+
+    parser.addoption(
         "--trusted-proxy", type=str,
         help="IP address of proxy we trust. See waitress documentation.")
 
@@ -680,6 +685,8 @@ class Config(object):
             kwargs["trusted_proxy_count"] = self.args.trusted_proxy_count
         if self.args.trusted_proxy_headers is not None:
             kwargs["trusted_proxy_headers"] = self.args.trusted_proxy_headers
+        if self.args.connection_limit is not None:
+            kwargs["connection_limit"] = self.args.connection_limit
         return dict(kwargs=kwargs, addresses=addresses)
 
     @cached_property

--- a/server/news/server-connection-limit.feature
+++ b/server/news/server-connection-limit.feature
@@ -1,0 +1,1 @@
+add a server option to pass a custom connection limit to waitress

--- a/server/test_devpi_server/test_main.py
+++ b/server/test_devpi_server/test_main.py
@@ -337,15 +337,23 @@ def test_init_server_directory(call_devpi_in_dir, tmpdir):
 
 
 def test_serve_threads(monkeypatch, tmpdir):
-    def check_threads(app, host, port, threads, max_request_body_size):
+    def check_threads(app, host, port, threads, connection_limit, max_request_body_size):
         assert threads == 100
     monkeypatch.setattr("waitress.serve", check_threads)
     from devpi_server.main import main
     main(["devpi-server", "--threads", "100"])
 
 
+def test_serve_connection_limit(monkeypatch, tmpdir):
+    def check_connection_limit(app, host, port, threads, connection_limit, max_request_body_size):
+        assert connection_limit == 200
+    monkeypatch.setattr("waitress.serve", check_connection_limit)
+    from devpi_server.main import main
+    main(["devpi-server", "--connection-limit", "200"])
+
+
 def test_serve_max_body(monkeypatch, tmpdir):
-    def check_max_body(app, host, port, threads, max_request_body_size):
+    def check_max_body(app, host, port, threads, connection_limit, max_request_body_size):
         assert max_request_body_size == 42
     monkeypatch.setattr("waitress.serve", check_max_body)
     from devpi_server.main import main


### PR DESCRIPTION
devpi-server currently runs with a hardcoded limit of 100 simulatenous connections, enforced through its waitress dependency. This can be limiting in production environments where devpi may need to handle more, or where connections are kept open by a pooler (load balancer, front HTTP server, ...).

This PR adds a `--connection-limit` parameter allowing administrators to tailor this limit to their needs and resources.