### PR TITLE
Bugfix: apply Basic auth to HTTP API URLs with a query string.

### DIFF
--- a/client/devpi/use.py
+++ b/client/devpi/use.py
@@ -99,6 +99,9 @@ class Current:
         # searches for longest match, so there can be multiple devpi instances
         # on the same domain with different paths
         url = URL(url)
+        # Strip the query part, if any, because otherwise a URL with parameters
+        # unexpectedly does not match the one stored in the auth mapping.
+        url = url.replace(query=None)
         while url:
             if url in d or url.path == '/':
                 break

--- a/client/news/965.bugfix
+++ b/client/news/965.bugfix
@@ -1,0 +1,2 @@
+The stored basic authentication credentials are now correctly applied to
+HTTP API URLs containing a query string.

--- a/client/testing/test_use.py
+++ b/client/testing/test_use.py
@@ -442,6 +442,8 @@ class TestUnit:
         assert mock_http_api.called[0][2]['basic_auth'] == ('user', 'password')
         assert mock_http_api.called[1][1].path == '/foo/bar'
         assert mock_http_api.called[1][2]['basic_auth'] is None  # http_api should do the lookup
+        # previously, requesting a URL with query would yield no auth
+        assert hub.current.get_basic_auth(url="https://devpi/foo/bar?no_projects='") == ('user', 'password')
 
     def test_change_index(self, cmd_devpi, mock_http_api):
         mock_http_api.set("http://world.com/+api", result=dict(

--- a/client/testing/test_use.py
+++ b/client/testing/test_use.py
@@ -443,7 +443,7 @@ class TestUnit:
         assert mock_http_api.called[1][1].path == '/foo/bar'
         assert mock_http_api.called[1][2]['basic_auth'] is None  # http_api should do the lookup
         # previously, requesting a URL with query would yield no auth
-        assert hub.current.get_basic_auth(url="https://devpi/foo/bar?no_projects='") == ('user', 'password')
+        assert hub.current.get_basic_auth(url="https://devpi/foo/bar?no_projects=") == ('user', 'password')
 
     def test_change_index(self, cmd_devpi, mock_http_api):
         mock_http_api.set("http://world.com/+api", result=dict(


### PR DESCRIPTION
Fixes #965.