### PR TITLE
nginx-devpi-caching.conf: Add uv to devpi_installer_agent to allow caching

### DIFF
--- a/server/devpi_server/cfg/nginx-devpi-caching-http.conf.template
+++ b/server/devpi_server/cfg/nginx-devpi-caching-http.conf.template
@@ -9,6 +9,7 @@ map $http_user_agent $devpi_installer_agent {
         ~*setuptools/   1;
         ~*pip/          1;
         ~*pex/          1;
+        ~*uv/           1;
 }
 
 map $http_accept $devpi_installer_accept {


### PR DESCRIPTION
Example uv user-agent

```
uv/0.10.3 {"installer":{"name":"uv","version":"0.10.3","subcommand":["pip","install"]},"python":"3.10.9","implementation":{"name":"CPython","version":"3.10.9"},"distro":null,"system":{"name":"Windows","release":"10"},"cpu":"AMD64","openssl_version":null,"setuptools_version":null,"rustc_version":null,"ci":null}
```
vs pip
```
pip/26.0.1 {"ci":null,"cpu":"AMD64","implementation":{"name":"CPython","version":"3.10.9"},"installer":{"name":"pip","version":"26.0.1"},"openssl_version":"OpenSSL 1.1.1q  5 Jul 2022","python":"3.10.9","setuptools_version":"81.0.0","system":{"name":"Windows","release":"10"}}
```