### PR TITLE
Add q, total, cached, limit, offset query parameters to GET /<user>/<index>

### DIFF
--- a/doc/curl.rst
+++ b/doc/curl.rst
@@ -56,12 +56,73 @@ Looking at list of projects in ``alice/dev`` index::
      $ curl -H "Accept: application/json" -s \
            -X GET http://localhost:3141/alice/dev/
      {
-       "status": 200, 
-       "type": "list:projectconfig", 
+       "status": 200,
+       "type": "list:projectconfig",
        "result": [
          "example"
        ]
      }
+
+The project list supports several optional query parameters:
+
+``?q=<substring>``
+    Filter project names by substring match::
+
+        $ curl -H "Accept: application/json" -s \
+              http://localhost:3141/root/pypi?q=flask
+        {
+          "result": {"projects": ["flask", "flask-login", "flask-wtf"]}
+        }
+
+``?total=1``
+    Include the total count of (filtered) projects in the response::
+
+        $ curl -H "Accept: application/json" -s \
+              "http://localhost:3141/root/pypi?q=flask&total=1"
+        {
+          "result": {"projects": ["flask", "flask-login"], "total": 2}
+        }
+
+``?cached=1``
+    Include a ``cached`` list — projects that have locally cached metadata
+    (mirror indexes only)::
+
+        $ curl -H "Accept: application/json" -s \
+              http://localhost:3141/root/pypi?cached=1
+        {
+          "result": {
+            "projects": ["flask", "django", "requests"],
+            "cached": ["flask"]
+          }
+        }
+
+``?limit=<n>&offset=<n>``
+    Paginate the project list. When ``limit`` is present, ``offset`` and
+    ``limit`` are included in the response. ``offset`` defaults to 0::
+
+        $ curl -H "Accept: application/json" -s \
+              "http://localhost:3141/root/pypi?limit=2&offset=0"
+        {
+          "result": {
+            "projects": ["aiohttp", "attrs"],
+            "limit": 2,
+            "offset": 0
+          }
+        }
+
+All parameters can be combined freely::
+
+    $ curl -H "Accept: application/json" -s \
+          "http://localhost:3141/root/pypi?q=flask&cached=1&total=1&limit=10&offset=0"
+    {
+      "result": {
+        "projects": ["flask", "flask-login", "flask-wtf"],
+        "cached": ["flask"],
+        "total": 3,
+        "limit": 10,
+        "offset": 0
+      }
+    }
 
 Registering release files and docs (Unimplemented)
 -----------------------------------------------------------------

--- a/server/devpi_server/mirror.py
+++ b/server/devpi_server/mirror.py
@@ -769,6 +769,12 @@ class MirrorStage(BaseStage):
         """ return True if we have some cached simpelinks information. """
         return self.key_projsimplelinks(project).exists()
 
+    def get_cached_projects(self) -> frozenset[str]:
+        """Return normalized names of projects that have cached simplelinks."""
+        return frozenset(
+            project for project in self._stale_list_projects_perstage()
+            if self.key_projsimplelinks(project).exists())
+
     def _save_cache_links(
         self,
         project: NormalizedName | str,

--- a/server/devpi_server/views.py
+++ b/server/devpi_server/views.py
@@ -1657,7 +1657,36 @@ class PyPIView:
         # double negation :(
         add_projects = 'no_projects' not in self.request.GET
         if add_projects:
-            result['projects'] = sorted(stage.list_projects_perstage())
+            GET = self.request.GET
+            projects = sorted(stage.list_projects_perstage())
+
+            q = GET.get('q', '').strip()
+            if q:
+                projects = [p for p in projects if q in p]
+
+            if 'total' in GET:
+                result['total'] = len(projects)
+
+            if 'cached' in GET and hasattr(stage, 'get_cached_projects'):
+                cached = stage.get_cached_projects()
+                result['cached'] = sorted(p for p in projects if p in cached)
+
+            limit = offset = None
+            try:
+                if 'limit' in GET:
+                    limit = int(GET['limit'])
+                if 'offset' in GET:
+                    offset = int(GET['offset'])
+            except ValueError:
+                abort(self.request, 400, "limit and offset must be integers")
+
+            if limit is not None:
+                offset = offset or 0
+                result['offset'] = offset
+                result['limit'] = limit
+                projects = projects[offset:offset + limit]
+
+            result['projects'] = projects
         apireturn(200, type="indexconfig", result=result)
 
     @view_config(route_name="/{user}/{index}", accept="application/vnd.pypi.simple.v1+json", request_method="GET")

--- a/server/news/1122.feature
+++ b/server/news/1122.feature
@@ -1,0 +1,2 @@
+Add ``q``, ``cached``, ``total``, ``limit`` and ``offset`` query parameters to
+``GET /<user>/<index>`` for filtering, counting and paginating the project list.

--- a/server/test_devpi_server/test_views.py
+++ b/server/test_devpi_server/test_views.py
@@ -766,6 +766,124 @@ def test_indexroot_root_pypi(testapp, xom):
     assert "projects" not in r.json["result"]
 
 
+def test_index_get_q_filter(pypistage, testapp):
+    pypistage.mock_simple_projects(["flask", "flask-login", "django", "requests"])
+    r = testapp.get_json("/root/pypi?q=flask")
+    assert r.status_code == 200
+    assert r.json["result"]["projects"] == ["flask", "flask-login"]
+
+
+def test_index_get_q_filter_no_match(pypistage, testapp):
+    pypistage.mock_simple_projects(["flask", "django"])
+    r = testapp.get_json("/root/pypi?q=nonexistent")
+    assert r.status_code == 200
+    assert r.json["result"]["projects"] == []
+
+
+def test_index_get_total(pypistage, testapp):
+    pypistage.mock_simple_projects(["flask", "django", "requests"])
+    r = testapp.get_json("/root/pypi?total=1")
+    assert r.status_code == 200
+    assert r.json["result"]["total"] == 3
+    assert "total" not in testapp.get_json("/root/pypi").json["result"]
+
+
+def test_index_get_total_with_q(pypistage, testapp):
+    pypistage.mock_simple_projects(["flask", "flask-login", "django"])
+    r = testapp.get_json("/root/pypi?q=flask&total=1")
+    assert r.status_code == 200
+    assert r.json["result"]["total"] == 2
+    assert r.json["result"]["projects"] == ["flask", "flask-login"]
+
+
+def test_index_get_pagination(pypistage, testapp):
+    pypistage.mock_simple_projects(["aaa", "bbb", "ccc", "ddd", "eee"])
+    r = testapp.get_json("/root/pypi?limit=2&offset=0")
+    assert r.status_code == 200
+    result = r.json["result"]
+    assert result["projects"] == ["aaa", "bbb"]
+    assert result["limit"] == 2
+    assert result["offset"] == 0
+
+
+def test_index_get_pagination_second_page(pypistage, testapp):
+    pypistage.mock_simple_projects(["aaa", "bbb", "ccc", "ddd", "eee"])
+    r = testapp.get_json("/root/pypi?limit=2&offset=2")
+    assert r.status_code == 200
+    assert r.json["result"]["projects"] == ["ccc", "ddd"]
+
+
+def test_index_get_pagination_last_page(pypistage, testapp):
+    pypistage.mock_simple_projects(["aaa", "bbb", "ccc", "ddd", "eee"])
+    r = testapp.get_json("/root/pypi?limit=2&offset=4")
+    assert r.status_code == 200
+    assert r.json["result"]["projects"] == ["eee"]
+
+
+def test_index_get_pagination_invalid(pypistage, testapp):
+    r = testapp.get_json("/root/pypi?limit=abc", expect_errors=True)
+    assert r.status_code == 400
+
+
+def test_index_get_limit_without_offset(pypistage, testapp):
+    pypistage.mock_simple_projects(["aaa", "bbb", "ccc"])
+    r = testapp.get_json("/root/pypi?limit=2")
+    assert r.status_code == 200
+    result = r.json["result"]
+    assert result["projects"] == ["aaa", "bbb"]
+    assert result["offset"] == 0
+
+
+def test_index_get_cached(pypistage, testapp):
+    pypistage.mock_simple_projects(["flask", "django", "requests"])
+    # access flask to populate simplelinks cache
+    pypistage.mock_simple("flask", text='<a href="/flask-1.0.tar.gz"/>')
+    testapp.get("/root/pypi/+simple/flask/")
+    r = testapp.get_json("/root/pypi?cached=1")
+    assert r.status_code == 200
+    result = r.json["result"]
+    assert "cached" in result
+    assert "flask" in result["cached"]
+    assert "django" not in result["cached"]
+    assert "requests" not in result["cached"]
+
+
+def test_index_get_cached_with_q(pypistage, testapp):
+    pypistage.mock_simple_projects(["flask", "flask-login", "django"])
+    pypistage.mock_simple("flask", text='<a href="/flask-1.0.tar.gz"/>')
+    pypistage.mock_simple("flask-login", text='<a href="/flask-login-1.0.tar.gz"/>')
+    testapp.get("/root/pypi/+simple/flask/")
+    testapp.get("/root/pypi/+simple/flask-login/")
+    r = testapp.get_json("/root/pypi?q=flask&cached=1")
+    assert r.status_code == 200
+    result = r.json["result"]
+    assert result["projects"] == ["flask", "flask-login"]
+    assert set(result["cached"]) == {"flask", "flask-login"}
+
+
+def test_index_get_cached_not_on_non_mirror(testapp, model, xom):
+    with xom.keyfs.write_transaction():
+        user = model.create_user("user", "123")
+        user.create_stage("index")
+    r = testapp.get_json("/user/index?cached=1")
+    assert r.status_code == 200
+    assert "cached" not in r.json["result"]
+
+
+def test_index_get_combined(pypistage, testapp):
+    pypistage.mock_simple_projects(["aaa", "bbb", "ccc", "ddd", "eee"])
+    pypistage.mock_simple("bbb", text='<a href="/bbb-1.0.tar.gz"/>')
+    testapp.get("/root/pypi/+simple/bbb/")
+    r = testapp.get_json("/root/pypi?total=1&cached=1&limit=3&offset=0")
+    assert r.status_code == 200
+    result = r.json["result"]
+    assert result["total"] == 5
+    assert result["projects"] == ["aaa", "bbb", "ccc"]
+    assert result["cached"] == ["bbb"]
+    assert result["limit"] == 3
+    assert result["offset"] == 0
+
+
 @pytest.mark.parametrize("url", [
     '/root/pypi/{name}',
     '/root/pypi/{name}/2.6',


### PR DESCRIPTION
## Summary

Extends `GET /<user>/<index>` with opt-in query parameters for filtering,
counting and paginating the project list. Without parameters the endpoint
behaves exactly as today — fully backwards compatible.

- `?q=<substring>` — filter project names by substring
- `?total=1` — include total count of (filtered) projects
- `?cached=1` — include list of locally cached projects (mirror indexes only)
- `?limit=<n>&offset=<n>` — paginate the project list

All parameters compose freely:
GET /root/pypi?q=flask&cached=1&total=1&limit=20&offset=0

## Motivation

Building a dashboard UI over the devpi API that needs search-as-you-type and
infinite scroll over the project list — without downloading 17 MB on every
page load.

## Notes

- `?cached=1` uses existing `is_project_cached()` (DB lookup via keyfs, no filesystem scan)
- `?cached=1` is silently ignored on non-mirror indexes
- Parameters apply in order: q filter → total count → cached list → pagination slice

Closes #1122