### PR TITLE
Fix replica not appearing in polling_replicas when no new serials available

### DIFF
--- a/server/devpi_server/replica.py
+++ b/server/devpi_server/replica.py
@@ -330,7 +330,8 @@ class PrimaryChangelogRequest:
         start_serial = int(self.request.matchdict["serial"])
 
         keyfs = self.xom.keyfs
-        self._wait_for_serial(start_serial)
+        with self.update_replica_status(start_serial):
+            self._wait_for_serial(start_serial)
         devpi_serial = keyfs.tx.conn.last_changelog_serial
         threadlog.info("Streaming from %s to %s", start_serial, devpi_serial)
 


### PR DESCRIPTION
`get_streaming_changes` calls `update_replica_status` only inside the `iter_changelog_entries generator`, which is never entered when `_wait_for_serial` raises `HTTPAccepted` (202 — no new serial available). As a result, a replica that is fully caught up never appears in `polling_replicas` on the master.

Fix: call `update_replica_status` before `_wait_for_serial`, so the replica is registered on the master regardless of whether new data is available.

The non-streaming path (`get_multiple_changes`) does not have this issue — it calls `update_replica_status` as a context manager wrapping `_wait_for_serial` directly.
