### PR TITLE
Fix core-metadata extraction for dotted package names. Refs #1018

### DIFF
--- a/server/devpi_server/views.py
+++ b/server/devpi_server/views.py
@@ -1631,11 +1631,18 @@ class PyPIView:
             return apireturn(502, e.args[0])
 
         if is_metadata:
-            metadata_filename = (
-                f"{entry.project.replace('-', '_')}-{entry.version}.dist-info/METADATA"
-            )
             with entry.file_open_read() as f, ZipFile(f) as zf:
-                wheel_metadata_contents = zf.read(metadata_filename)
+                # find the single .dist-info/METADATA in the wheel,
+                # as the dirname may not match the normalized project name
+                # (e.g. jaraco.classes keeps the dot)
+                candidates = [
+                    n for n in zf.namelist()
+                    if n.endswith(".dist-info/METADATA")
+                    and n.count("/") == 1
+                ]
+                if not candidates:
+                    abort(request, 404, "no METADATA in wheel")
+                wheel_metadata_contents = zf.read(candidates[0])
             return Response(
                 body=wheel_metadata_contents,
                 content_type="application/octet-stream",


### PR DESCRIPTION
Requesting .whl.metadata for a cached wheel whose distribution name contains dots (e.g. jaraco.classes, ruamel.yaml) returns 500.

The dist-info directory inside the wheel keeps the original name verbatim (jaraco.classes-3.4.0.dist-info/), but the code reconstructs it from the normalized project name.

https://github.com/devpi/devpi/blob/d35f2b035ab386d9e915a1e7f12c4405a0cbab03/server/devpi_server/views.py#L1634-L1636

This PR fix the issue by find the single `*.dist-info/METADATA` entry in the zip namelist instead of guessing the name.
PEP 427 guarantees one dist-info directory per wheel.

For example, expected metadata url for jaraco.classes is:
```
https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl.metadata
```
which contains the dot in the filename.